### PR TITLE
fix: resolve spec numbering in worktrees

### DIFF
--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -44,25 +44,14 @@ Given that feature description, do this:
       git fetch --all --prune
       ```
 
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+   b. **Do not calculate the number manually.** The script already computes the next available feature number by scanning branches and the `specs/` directory (including worktrees). This avoids resetting to 001 when the short-name is new.
 
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   c. Run the script once with the short-name and description (no manual number override):
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Let the script determine the next available number; do not pre-filter by short-name
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -84,19 +84,42 @@ find_repo_root() {
 get_highest_from_specs() {
     local specs_dir="$1"
     local highest=0
-    
+    local highest_tree=0
+    local highest_fs=0
+
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        local tree_entries=""
+        tree_entries=$(git ls-tree -d --name-only HEAD "specs" 2>/dev/null || echo "")
+        if [ -n "$tree_entries" ]; then
+            while IFS= read -r entry; do
+                [ -z "$entry" ] && continue
+                dirname=$(basename "$entry")
+                number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
+                number=$((10#$number))
+                if [ "$number" -gt "$highest_tree" ]; then
+                    highest_tree=$number
+                fi
+            done <<< "$tree_entries"
+        fi
+    fi
+
     if [ -d "$specs_dir" ]; then
         for dir in "$specs_dir"/*; do
             [ -d "$dir" ] || continue
             dirname=$(basename "$dir")
             number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
             number=$((10#$number))
-            if [ "$number" -gt "$highest" ]; then
-                highest=$number
+            if [ "$number" -gt "$highest_fs" ]; then
+                highest_fs=$number
             fi
         done
     fi
-    
+
+    highest=$highest_tree
+    if [ "$highest_fs" -gt "$highest" ]; then
+        highest=$highest_fs
+    fi
+
     echo "$highest"
 }
 


### PR DESCRIPTION
## Summary
- read highest spec number from git tree and filesystem to work in worktrees
- update speckit.specify instructions to rely on script-based numbering

## Testing
- bun run lint (repos/arashi)
- bun test (repos/arashi)
- bun run build (repos/arashi)