### PR TITLE
specs: add fix remove confirmation docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ config-mgmt/
 - GitHub repository (tags, releases, artifacts), npm registry (019-release-workflow)
 - File system (`.arashi/config.json` for workspace configuration, git metadata from `.git/worktrees/`) (020-status-command)
 - TypeScript (latest stable) with Bun (latest stable version for bundling and runtime) + commander (CLI framework), chalk (colored output), ora (spinners), @inquirer/prompts (user prompts), Bun runtime (built-in APIs - spawn, file system, path) (021-remove-command)
+- TypeScript (latest stable) + Bun (latest stable) + commander, chalk, ora, @inquirer/prompts (023-fix-remove-confirmation)
+- File system (`.arashi/config.json`, git metadata, worktree directories) (023-fix-remove-confirmation)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -84,9 +86,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 023-fix-remove-confirmation: Added TypeScript (latest stable) + Bun (latest stable) + commander, chalk, ora, @inquirer/prompts
 - 021-remove-command: Added TypeScript (latest stable) with Bun (latest stable version for bundling and runtime) + commander (CLI framework), chalk (colored output), ora (spinners), @inquirer/prompts (user prompts), Bun runtime (built-in APIs - spawn, file system, path)
 - 020-status-command: Added TypeScript (latest stable) with Bun (latest stable version for bundling and runtime)
-- 019-release-workflow: Added YAML (GitHub Actions workflow syntax v2)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/023-fix-remove-confirmation/checklists/requirements.md
+++ b/specs/023-fix-remove-confirmation/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Fix Remove Command Confirmation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass on initial review.

--- a/specs/023-fix-remove-confirmation/contracts/remove-command.openapi.yaml
+++ b/specs/023-fix-remove-confirmation/contracts/remove-command.openapi.yaml
@@ -1,0 +1,123 @@
+openapi: 3.0.3
+info:
+  title: Remove Command Flow
+  version: 1.0.0
+  description: Contract for interactive worktree removal flow.
+servers:
+  - url: https://localhost
+paths:
+  /worktrees:
+    get:
+      summary: List selectable worktrees
+      responses:
+        "200":
+          description: Worktree list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Worktree"
+  /worktrees/selection:
+    post:
+      summary: Submit selected worktrees
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SelectionRequest"
+      responses:
+        "200":
+          description: Selection accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SelectionResponse"
+        "400":
+          description: No selection made
+  /worktrees/confirm:
+    post:
+      summary: Confirm removal of selected worktrees or branches
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfirmationRequest"
+      responses:
+        "200":
+          description: Removal completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfirmationResponse"
+        "404":
+          description: One or more branches invalid
+        "409":
+          description: Confirmation declined
+  /worktrees/cancel:
+    post:
+      summary: Cancel the selection or confirmation flow
+      responses:
+        "200":
+          description: Flow cancelled
+components:
+  schemas:
+    Worktree:
+      type: object
+      required:
+        - id
+        - path
+        - branch
+      properties:
+        id:
+          type: string
+        path:
+          type: string
+        branch:
+          type: string
+        isLocked:
+          type: boolean
+        isDirty:
+          type: boolean
+    SelectionRequest:
+      type: object
+      required:
+        - worktreeIds
+      properties:
+        worktreeIds:
+          type: array
+          items:
+            type: string
+    SelectionResponse:
+      type: object
+      required:
+        - nextStep
+      properties:
+        nextStep:
+          type: string
+          enum:
+            - confirm-removal
+    ConfirmationRequest:
+      type: object
+      required:
+        - confirm
+      properties:
+        confirm:
+          type: boolean
+        worktreeIds:
+          type: array
+          items:
+            type: string
+        branches:
+          type: array
+          items:
+            type: string
+    ConfirmationResponse:
+      type: object
+      required:
+        - removedCount
+      properties:
+        removedCount:
+          type: integer

--- a/specs/023-fix-remove-confirmation/data-model.md
+++ b/specs/023-fix-remove-confirmation/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Fix Remove Command Confirmation
+
+## Entities
+
+### WorktreeSelection
+
+- Fields:
+  - `selectedWorktrees`: string[] (worktree identifiers or paths)
+  - `submittedAt`: string (ISO timestamp)
+  - `source`: "interactive"
+- Validation rules:
+  - Must be an array (may be empty if user submits without selection)
+  - If empty, a clear message must be shown and the flow must remain controlled
+
+### RemovalConfirmation
+
+- Fields:
+  - `confirmed`: boolean
+  - `requestedAt`: string (ISO timestamp)
+  - `context`: "selection" | "branch"
+  - `targets`: string[] (worktree ids or branch inputs)
+- Validation rules:
+  - `confirmed` must be explicitly set by the user before any removal
+  - If `confirmed` is false, no removals occur
+
+### BranchInput
+
+- Fields:
+  - `branches`: string[]
+  - `resolvedWorktrees`: string[]
+  - `invalidBranches`: string[]
+- Validation rules:
+  - All provided branch names must resolve to a worktree; invalid entries cause an error and abort removal
+
+## Relationships
+
+- A `WorktreeSelection` can lead to a `RemovalConfirmation` with `context="selection"`.
+- A `BranchInput` can lead to a `RemovalConfirmation` with `context="branch"`.
+
+## State Transitions
+
+- Worktree selection: `idle -> selecting -> submitted -> (confirmed | cancelled)`
+- Confirmation: `pending -> confirmed -> removed` or `pending -> declined -> exited`

--- a/specs/023-fix-remove-confirmation/plan.md
+++ b/specs/023-fix-remove-confirmation/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Fix Remove Command Confirmation
+
+**Branch**: `023-fix-remove-confirmation` | **Date**: 2026-02-07 | **Spec**: `specs/023-fix-remove-confirmation/spec.md`
+**Input**: Feature specification from `specs/023-fix-remove-confirmation/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Fix the remove command so interactive selection does not exit early, branch-based removal always asks for confirmation, and non-interactive runs fail with a clear message. The approach keeps the CLI flow in the command handler using `@inquirer/prompts`, adds a non-TTY guard before prompting, and preserves existing commander + chalk/ora output conventions.
+
+## Technical Context
+
+**Language/Version**: TypeScript (latest stable) + Bun (latest stable)  
+**Primary Dependencies**: commander, chalk, ora, @inquirer/prompts  
+**Storage**: File system (`.arashi/config.json`, git metadata, worktree directories)  
+**Testing**: Bun test runner (`bun test`)  
+**Target Platform**: macOS, Linux, Windows (CLI)  
+**Project Type**: Single CLI project  
+**Performance Goals**: Remove/list interactions complete in <2s for typical worktree counts; no noticeable prompt lag  
+**Constraints**: Single-file executable distribution, cross-platform path handling, interactive prompts require TTY, confirmation required for destructive actions  
+**Scale/Scope**: Worktree counts typically 1-50 across a multi-repo workspace; single command path update
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- PASS: Single-file executable remains intact (no new runtime dependencies)
+- PASS: Worktree coordination behavior unchanged; only remove flow adjustments
+- PASS: Error recovery/rollback preserved; no partial deletion paths added
+- PASS: User-centric output improved with clear prompts/messages
+- PASS: Minimal configuration (no new config fields)
+- PASS: Cross-platform compatibility preserved (TTY checks use standard APIs)
+- PASS: Test coverage requirement acknowledged for implementation phase
+- PASS: Semantic versioning unchanged (bug fix)
+- PASS: Hook system unaffected
+- PASS: Performance standards maintained (prompt flow only)
+
+Re-check after Phase 1 design: PASS (design artifacts introduce no new violations).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-fix-remove-confirmation/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── src/
+└── tests/
+```
+
+**Structure Decision**: Single CLI project in `repos/arashi/` using the existing `src/` and `tests/` layout.
+
+## Complexity Tracking
+
+No constitutional violations identified.

--- a/specs/023-fix-remove-confirmation/quickstart.md
+++ b/specs/023-fix-remove-confirmation/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Fix Remove Command Confirmation
+
+## Prerequisites
+
+- Run in an interactive terminal (TTY) for prompts.
+- Use the installed `arashi` CLI from your PATH.
+
+## Interactive selection flow
+
+```bash
+arashi remove
+```
+
+- Select one or more worktrees and submit the selection.
+- The command continues to the confirmation step instead of exiting.
+
+## Branch-driven removal with confirmation
+
+```bash
+arashi remove <branch-name>
+```
+
+- A confirmation prompt appears before any removal.
+- Declining the prompt exits without changes.
+
+## Non-interactive behavior
+
+If stdin is not a TTY, the command exits with a clear message.
+
+```bash
+echo "y" | arashi remove
+```

--- a/specs/023-fix-remove-confirmation/research.md
+++ b/specs/023-fix-remove-confirmation/research.md
@@ -1,0 +1,31 @@
+# Research: Fix Remove Command Confirmation
+
+## Decision 1: Use `@inquirer/prompts` with explicit cancellation handling
+
+- Decision: Keep prompts in the command handler and wrap them with a small helper that catches `ExitPromptError`/`AbortPromptError`, returning a controlled result instead of exiting the process.
+- Rationale: Ensures the selection flow stays open until a submit or explicit cancel, and avoids premature exits on Ctrl+C or aborted prompts.
+- Alternatives considered: Raw `readline` prompts (more manual state handling), full `inquirer` package (heavier, not needed for single prompts).
+
+## Decision 2: Guard prompts with a non-interactive check
+
+- Decision: Check `process.stdin.isTTY` before invoking prompts and fail with a clear error if not interactive.
+- Rationale: Prevents hanging or rejected prompts in CI/piped environments and meets the non-interactive requirement.
+- Alternatives considered: Allow prompts in non-TTY with fallback defaults (risky for destructive actions), environment variable overrides only.
+
+## Decision 3: Preserve commander-driven argument parsing and validation
+
+- Decision: Validate branch arguments in the command action and use `program.error()` for consistent exit messaging.
+- Rationale: Centralizes argument validation and ensures clean exit codes without stack traces.
+- Alternatives considered: Manual argument parsing inside the command logic (less consistent with existing CLI patterns).
+
+## Decision 4: Maintain chalk/ora output patterns with TTY-aware spinners
+
+- Decision: Keep using chalk for color and ora for spinners; rely on ora's non-TTY disable behavior and provide clear text output.
+- Rationale: Meets user-centric output expectations without breaking logs in CI.
+- Alternatives considered: Plain console output only (less informative in interactive mode), custom spinner implementation.
+
+## Decision 5: Resolve branch inputs via worktree listing before removal
+
+- Decision: Map branch inputs to worktree entries using `git worktree list --porcelain`, and error clearly on invalid branches before prompting for confirmation.
+- Rationale: Aligns with common git tooling safety patterns and prevents accidental deletion of the wrong worktree.
+- Alternatives considered: Passing branch names directly to `git worktree remove` (fails with ambiguous errors), skipping confirmation for branch removal (violates requirements).

--- a/specs/023-fix-remove-confirmation/spec.md
+++ b/specs/023-fix-remove-confirmation/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Fix Remove Command Confirmation
+
+**Feature Branch**: `023-fix-remove-confirmation`  
+**Created**: 2026-02-07  
+**Status**: Draft  
+**Input**: User description: "I am having an issue with the arashi remove command. When I run the command through the installed package, the command exits before I can select and submit the worktrees I want to remove. If I provide a branch, I don't get the ability to confirm the delete and the command exits."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Select worktrees to remove (Priority: P1)
+
+As a user running the remove command interactively, I want to select one or more worktrees and submit my selection without the command exiting early, so I can remove the intended worktrees in a single run.
+
+**Why this priority**: This is the primary workflow for safely removing worktrees and is currently blocked by premature exit.
+
+**Independent Test**: Can be fully tested by running the remove command interactively, selecting worktrees, submitting the selection, and verifying the command continues to the next step instead of exiting.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal session, **When** I open the worktree selection, choose one or more worktrees, and submit, **Then** the command proceeds to the next step without exiting early.
+2. **Given** an interactive terminal session, **When** I open the worktree selection and submit without making a selection, **Then** I receive a clear message and the command remains in a controlled flow (no abrupt exit).
+
+---
+
+### User Story 2 - Confirm removal when a branch is provided (Priority: P2)
+
+As a user providing a branch directly to the remove command, I want to be prompted to confirm the deletion before any removal happens, so I can avoid accidental deletes.
+
+**Why this priority**: Direct branch removal should remain safe and consistent with interactive safeguards.
+
+**Independent Test**: Can be fully tested by running the remove command with a branch argument and confirming that a deletion confirmation prompt appears before any removal proceeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal session and a valid branch argument, **When** I run the remove command, **Then** I am prompted to confirm deletion before any worktree is removed.
+2. **Given** an interactive terminal session and a valid branch argument, **When** I decline the confirmation, **Then** no worktrees are removed and the command exits cleanly.
+
+---
+
+### User Story 3 - Clear behavior in non-interactive runs (Priority: P3)
+
+As a user running the remove command in a non-interactive environment, I want a clear, immediate response that interactive input is required, so I understand why the operation cannot proceed.
+
+**Why this priority**: Ensures predictable behavior in CI or scripted environments and prevents silent failures.
+
+**Independent Test**: Can be fully tested by running the command with standard input not attached to a terminal and verifying a clear message and non-success exit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a non-interactive environment, **When** I run the remove command without a way to provide interactive input, **Then** the command exits with a clear message explaining that interactive input is required.
+
+---
+
+### Edge Cases
+
+- User submits a selection while the list of worktrees is empty.
+- User provides a branch that does not map to any worktree.
+- User cancels the selection or confirmation step.
+- User provides multiple branches and one or more are invalid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST keep the interactive selection flow open until the user submits a choice or explicitly cancels.
+- **FR-002**: The system MUST not exit immediately after selection submission; it must continue to the next step in the removal flow.
+- **FR-003**: When a branch is provided directly, the system MUST present a deletion confirmation before any removal is performed.
+- **FR-004**: If the user declines confirmation, the system MUST perform no removals and exit cleanly.
+- **FR-005**: In non-interactive environments, the system MUST provide a clear message indicating that interactive input is required.
+- **FR-006**: The system MUST present a clear message when no selectable worktrees are available.
+- **FR-007**: The system MUST handle invalid branches with a clear error message and no removals.
+
+### Key Entities *(include if feature involves data)*
+
+- **Worktree Selection**: A user-chosen set of worktrees intended for removal, including zero or more entries.
+- **Removal Confirmation**: The explicit user decision to proceed or cancel a deletion.
+- **Branch Input**: One or more branch identifiers supplied directly to the command.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 10 consecutive interactive runs, users can submit a worktree selection without the command exiting early.
+- **SC-002**: In 10 consecutive runs with a branch argument, the confirmation prompt appears before any removal is executed.
+- **SC-003**: 95% of users can complete the intended removal flow on the first attempt without accidental deletions.
+- **SC-004**: Non-interactive runs exit with a clear message in 100% of attempts.
+
+## Assumptions
+
+- The remove command is expected to run in an interactive terminal for selection and confirmation steps.
+- Declining confirmation should leave all worktrees unchanged.

--- a/specs/023-fix-remove-confirmation/tasks.md
+++ b/specs/023-fix-remove-confirmation/tasks.md
@@ -1,0 +1,160 @@
+# Tasks: Fix Remove Command Confirmation
+
+**Input**: Design documents from `/specs/023-fix-remove-confirmation/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Not requested (no test tasks included).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Shared prompt infrastructure required by multiple stories
+
+- [X] T001 Add prompt outcome types and cancellation-safe wrappers in `repos/arashi/src/lib/prompts.ts`
+- [X] T002 [P] Add non-interactive remove error code in `repos/arashi/src/lib/errors.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared remove-flow handling that blocks all user stories
+
+- [X] T003 Integrate prompt outcome handling into remove flow in `repos/arashi/src/commands/remove.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Select worktrees to remove (Priority: P1) 🎯 MVP
+
+**Goal**: Keep interactive selection open until submit/cancel and avoid early exit.
+
+**Independent Test**: Run `arashi remove`, select worktrees, submit, and verify the command proceeds to confirmation; submit with no selection and verify a clear message with a clean exit.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Keep selection flow open after submit and avoid premature exit in `repos/arashi/src/commands/remove.ts`
+- [X] T005 [US1] Emit a clear message when no selection is made and return a controlled exit in `repos/arashi/src/commands/remove.ts`
+
+**Checkpoint**: User Story 1 is fully functional and independently testable
+
+---
+
+## Phase 4: User Story 2 - Confirm removal when a branch is provided (Priority: P2)
+
+**Goal**: Always prompt for confirmation when a branch is provided unless forced.
+
+**Independent Test**: Run `arashi remove <branch>`, confirm that a prompt appears before any removal; decline and verify no worktrees are removed.
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Ensure branch-argument removal always prompts for confirmation and respects decline in `repos/arashi/src/commands/remove.ts`
+
+**Checkpoint**: User Story 2 is fully functional and independently testable
+
+---
+
+## Phase 5: User Story 3 - Clear behavior in non-interactive runs (Priority: P3)
+
+**Goal**: Fail fast with a clear message when prompts cannot run.
+
+**Independent Test**: Run `echo "y" | arashi remove` and verify a clear non-interactive error with non-success exit.
+
+### Implementation for User Story 3
+
+- [X] T007 [US3] Guard all prompt entry points with a TTY check and throw a clear error in `repos/arashi/src/commands/remove.ts`
+- [X] T008 [US3] Map the non-interactive error to clean CLI output/exit codes in `repos/arashi/src/commands/remove.ts`
+
+**Checkpoint**: User Story 3 is fully functional and independently testable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and cross-cutting refinements
+
+- [X] T009 [P] Update remove command usage notes for non-interactive behavior in `repos/arashi/README.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational phase completion
+- **Polish (Final Phase)**: Depends on desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - no dependency on other stories
+- **User Story 3 (P3)**: Can start after Foundational - no dependency on other stories
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 and T002 can run in parallel
+- **Polish**: T009 can run in parallel with any user story after code changes stabilize
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# No parallel tasks within US1 (single file flow changes)
+Task: "Keep selection flow open after submit" (repos/arashi/src/commands/remove.ts)
+Task: "Emit clear message on empty selection" (repos/arashi/src/commands/remove.ts)
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# No parallel tasks within US2 (single file flow changes)
+Task: "Ensure confirmation for branch removal" (repos/arashi/src/commands/remove.ts)
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+# No parallel tasks within US3 (single file flow changes)
+Task: "Guard prompts with TTY check" (repos/arashi/src/commands/remove.ts)
+Task: "Map non-interactive error output" (repos/arashi/src/commands/remove.ts)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **Stop and validate**: Run the US1 independent test
+
+### Incremental Delivery
+
+1. Setup + Foundational
+2. User Story 1 → validate
+3. User Story 2 → validate
+4. User Story 3 → validate
+5. Polish documentation updates
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- Each user story is independently completable and testable


### PR DESCRIPTION
## Summary
- add full spec, plan, research, data model, contracts, and quickstart for fix-remove-confirmation
- capture checklist status and task breakdown
- update AGENTS feature tracking for 023

## Testing
- not run (docs only)