### PR TITLE
specs: add pull command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ config-mgmt/
 - File system (`.arashi/config.json`, git metadata, worktree directories) (023-fix-remove-confirmation)
 - TypeScript 5.9 + Bun (latest stable) + commander, chalk, ora, @inquirer/prompts (024-fix-remove-grouping)
 - File system (`.git/worktrees`, worktree paths), `.arashi/config.json` (024-fix-remove-grouping)
+- TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts (025-pull-command)
+- Workspace configuration in `.arashi/config.json`, repository metadata on disk (025-pull-command)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -88,9 +90,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 025-pull-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 - 024-fix-remove-grouping: Added TypeScript 5.9 + Bun (latest stable) + commander, chalk, ora, @inquirer/prompts
 - 023-fix-remove-confirmation: Added TypeScript (latest stable) + Bun (latest stable) + commander, chalk, ora, @inquirer/prompts
-- 021-remove-command: Added TypeScript (latest stable) with Bun (latest stable version for bundling and runtime) + commander (CLI framework), chalk (colored output), ora (spinners), @inquirer/prompts (user prompts), Bun runtime (built-in APIs - spawn, file system, path)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/025-pull-command/checklists/requirements.md
+++ b/specs/025-pull-command/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Pull Command
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-08
+**Feature**: specs/025-pull-command/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/025-pull-command/contracts/pull-command.openapi.yaml
+++ b/specs/025-pull-command/contracts/pull-command.openapi.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.3
+info:
+  title: Pull Command Contract
+  version: 1.0.0
+  description: Contract for initiating and reporting repository pull operations.
+paths:
+  /pull:
+    post:
+      summary: Run pull across repositories
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PullRequest'
+      responses:
+        '200':
+          description: Pull run completed with per-repository results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PullSummary'
+        '400':
+          description: Invalid request or configuration
+        '409':
+          description: One or more repositories require manual update
+components:
+  schemas:
+    PullRequest:
+      type: object
+      properties:
+        only:
+          type: array
+          items:
+            type: string
+          description: Repository identifiers to include
+        verbose:
+          type: boolean
+          description: Whether to include full output in results
+        timeoutSeconds:
+          type: integer
+          minimum: 1
+      additionalProperties: false
+    PullSummary:
+      type: object
+      properties:
+        overallStatus:
+          type: string
+          enum: [success, partial-failure, failure]
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PullResult'
+      required: [overallStatus, results]
+      additionalProperties: false
+    PullResult:
+      type: object
+      properties:
+        repositoryId:
+          type: string
+        status:
+          type: string
+          enum: [updated, skipped, failed, manual-update]
+        elapsedSeconds:
+          type: number
+        errorMessage:
+          type: string
+      required: [repositoryId, status, elapsedSeconds]
+      additionalProperties: false

--- a/specs/025-pull-command/data-model.md
+++ b/specs/025-pull-command/data-model.md
@@ -1,0 +1,35 @@
+# Phase 1 Data Model: Pull Command
+
+## Entities
+
+### WorkspaceConfiguration
+
+- **Attributes**: repository list, repository identifiers, repository paths
+- **Relationships**: 1-to-many with Repository
+
+### Repository
+
+- **Attributes**: identifier, local path, remote reference, working state (clean/dirty)
+- **Relationships**: belongs to WorkspaceConfiguration; has many PullResults over time
+
+### RemoteChangeStatus
+
+- **Attributes**: repository identifier, hasRemoteChanges (yes/no), checkedAt
+- **Relationships**: derived from Repository
+
+### PullResult
+
+- **Attributes**: repository identifier, status (updated/skipped/failed/manual-update), elapsedTime, errorMessage (optional)
+- **Relationships**: derived from Repository and RemoteChangeStatus
+
+## Validation Rules
+
+- Repository identifiers must be unique within a WorkspaceConfiguration.
+- A PullResult must include a status and elapsed time for every processed repository.
+- Manual-update status must include a human-readable error reason.
+
+## State Transitions
+
+- Repository: clean → updated (on successful pull)
+- Repository: dirty + remote changes → manual-update (on conflict/error and rollback)
+- Repository: clean + no remote changes → skipped

--- a/specs/025-pull-command/plan.md
+++ b/specs/025-pull-command/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Pull Command
+
+**Branch**: `025-pull-command` | **Date**: 2026-02-08 | **Spec**: specs/025-pull-command/spec.md
+**Input**: Feature specification from `specs/025-pull-command/spec.md`
+
+## Summary
+
+Implement the `arashi pull` command to update eligible repositories from their remotes with filtering, progress output, timing, verbose diagnostics, rollback on conflict or error, and a non-zero exit status on failures, with integration tests covering success and error flows.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9
+**Primary Dependencies**: Bun runtime, commander, chalk, ora, @inquirer/prompts
+**Storage**: Workspace configuration in `.arashi/config.json`, repository metadata on disk
+**Testing**: Bun test (integration focus for commands)
+**Target Platform**: macOS, Linux, Windows
+**Project Type**: single CLI project
+**Performance Goals**: Update 20 repositories in under 5 minutes when no conflicts occur
+**Constraints**: Cross-platform path handling, no partial updates on conflict/error, non-zero exit on any failure
+**Scale/Scope**: Typical workspaces with 1-50 repositories
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Single-File Executable: PASS (no change to distribution model)
+- Automatic Worktree Management: PASS (no conflict with worktree behavior)
+- Error Recovery & Rollback: PASS (revert pull on conflict/error per repo)
+- User-Centric Interface: PASS (progress, timing, verbose output, clear errors)
+- Minimalist Configuration: PASS (uses existing `.arashi/config.json`)
+- Cross-Platform Compatibility: PASS (Bun APIs and git tooling)
+- Test Coverage >80%: PASS (integration tests required)
+- Semantic Versioning: PASS (no versioning policy change)
+- Hook System: PASS (not applicable to pull command)
+- Performance Standards: PASS (progress indicators, target timing in goals)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-pull-command/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── src/
+│   ├── commands/
+│   │   └── pull.ts
+│   └── lib/
+│       └── (shared utilities for config, git, output)
+└── tests/
+    └── integration/
+        └── pull.test.ts
+```
+
+**Structure Decision**: Single CLI project under `repos/arashi`, adding `src/commands/pull.ts` and integration tests in `tests/integration`.
+
+## Complexity Tracking
+
+No constitutional violations identified.

--- a/specs/025-pull-command/quickstart.md
+++ b/specs/025-pull-command/quickstart.md
@@ -1,0 +1,29 @@
+# Phase 1 Quickstart: Pull Command
+
+## Goal
+
+Update eligible repositories in the workspace while reporting progress and outcomes.
+
+## Basic Usage
+
+```bash
+arashi pull
+```
+
+## Targeted Repositories
+
+```bash
+arashi pull --only repo-a --only repo-b
+```
+
+## Verbose Diagnostics
+
+```bash
+arashi pull --verbose
+```
+
+## Expected Outcomes
+
+- Each repository is reported as updated, skipped, failed, or manual-update.
+- Any conflict or error triggers a rollback for that repository and a manual-update status.
+- The command exits non-zero if any repository fails or needs manual update.

--- a/specs/025-pull-command/research.md
+++ b/specs/025-pull-command/research.md
@@ -1,0 +1,19 @@
+# Phase 0 Research: Pull Command
+
+## Decision 1: Configuration source
+
+- **Decision**: Use the existing workspace configuration file as the single source of repository scope.
+- **Rationale**: Matches the minimalist configuration principle and avoids introducing new configuration paths.
+- **Alternatives considered**: Auto-discovery only; rejected because the spec requires a subset filter that relies on configured identifiers.
+
+## Decision 2: Failure handling and rollback
+
+- **Decision**: Attempt the update, then revert on conflict or error and mark the repository for manual update.
+- **Rationale**: Aligns with the constitution's rollback principle and the clarified acceptance scenario.
+- **Alternatives considered**: Pre-check and skip dirty repositories; rejected because it prevents valid fast-forward pulls and contradicts the clarified behavior.
+
+## Decision 3: Result reporting and exit status
+
+- **Decision**: Always emit per-repository results and exit non-zero if any repository fails or needs manual update.
+- **Rationale**: Provides clear diagnostics for users and supports automation/CI usage.
+- **Alternatives considered**: Always exit zero; rejected because failures would be harder to detect in scripts.

--- a/specs/025-pull-command/spec.md
+++ b/specs/025-pull-command/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Pull Command
+
+**Feature Branch**: `025-pull-command`  
+**Created**: 2026-02-08  
+**Status**: Draft  
+**Input**: User description: "Implement Pull Command (https://github.com/corwinm/arashi-arashi/issues/60)"
+
+## Clarifications
+
+### Session 2026-02-08
+
+- Q: For acceptance scenario 2, should the system attempt a pull and revert on conflict/error while reporting the repository for manual update? → A: Attempt the pull; if there is a conflict or error, revert the pull and report the repository as needing manual update.
+- Q: What should the exit status be when any repository fails or needs manual update? → A: Exit non-zero if any repository fails or needs manual update.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Update All Eligible Repositories (Priority: P1)
+
+As a workspace user, I want a single command that pulls remote changes for all eligible repositories so I can update my workspace quickly and safely.
+
+**Why this priority**: This is the core value of the command and enables the primary workflow.
+
+**Independent Test**: Can be fully tested by running the command in a workspace with multiple clean repositories that have remote changes and verifying all eligible repositories are updated with a clear summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace configuration with multiple clean repositories and remote changes, **When** I run the pull command, **Then** each eligible repository is updated and reported as successful.
+2. **Given** a repository with local changes and remote changes, **When** I run the pull command, **Then** the command attempts the update, reverts it on conflict or error, and reports the repository as needing manual update.
+
+---
+
+### User Story 2 - Targeted Pulls (Priority: P2)
+
+As a workspace user, I want to limit the pull command to a subset of repositories so I can update only what I care about.
+
+**Why this priority**: Targeted updates reduce unnecessary work and time when only specific repositories matter.
+
+**Independent Test**: Can be fully tested by running the command with a subset filter and verifying only the specified repositories are considered and updated if eligible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with multiple repositories, **When** I run the pull command with a subset filter, **Then** only repositories in that subset are processed.
+2. **Given** a repository in scope with no remote changes, **When** I run the pull command, **Then** it is skipped and reported as having no updates.
+
+---
+
+### User Story 3 - Clear Progress and Diagnostics (Priority: P3)
+
+As a workspace user, I want clear progress, timing, and diagnostics so I can understand what happened during the pull operation and troubleshoot failures.
+
+**Why this priority**: Transparency reduces confusion and speeds up recovery when issues occur.
+
+**Independent Test**: Can be fully tested by running the command in verbose and non-verbose modes with at least one failure and verifying progress updates, timing, and error details are reported.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pull command is running across multiple repositories, **When** it processes each repository, **Then** progress is displayed and each repository shows a completion status and elapsed time.
+2. **Given** verbose mode is enabled, **When** a repository pull runs, **Then** the full output is shown for that repository and any failures include a clear reason.
+
+---
+
+### Edge Cases
+
+- Workspace configuration is missing or invalid.
+- No repositories are configured or none match the subset filter.
+- All repositories are already up to date.
+- A repository has local changes and remote changes at the same time.
+- A pull produces conflicts or errors and must be rolled back.
+- A repository cannot be reached due to authentication or network issues.
+- A pull operation exceeds the configured timeout.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST load the workspace configuration before processing repositories.
+- **FR-002**: System MUST allow users to limit the scope of repositories using a subset filter.
+- **FR-003**: System MUST detect which in-scope repositories have remote changes before attempting to update them.
+- **FR-004**: System MUST attempt to update repositories with local changes and remote changes, then revert the update and report the repository when a conflict or error occurs.
+- **FR-005**: System MUST update each eligible repository that is clean and has remote changes.
+- **FR-006**: System MUST display progress for each repository, including a completion status.
+- **FR-007**: System MUST report the elapsed time for each repository operation.
+- **FR-008**: System MUST provide a verbose mode that shows full output for each repository operation.
+- **FR-009**: System MUST handle operation failures and timeouts with clear error reporting and a final summary.
+- **FR-010**: System MUST exit with a non-zero status if any repository fails or requires manual update.
+
+### Scope
+
+- In scope: Updating repositories defined in the workspace configuration that have remote changes.
+- In scope: Reporting status, timing, and errors for each repository processed.
+- Out of scope: Resolving merge conflicts or modifying repository configuration.
+
+### Assumptions
+
+- If a repository fails to update, the command continues processing remaining repositories and reports all failures in the summary.
+- If no repositories are eligible, the command completes successfully with a clear message.
+- The subset filter references repositories defined in the workspace configuration.
+
+### Dependencies
+
+- Workspace configuration is available and readable at runtime.
+- Repositories have an accessible remote source for checking and pulling updates.
+
+### Key Entities *(include if feature involves data)*
+
+- **Workspace Configuration**: Defines which repositories are part of the workspace and their identifiers.
+- **Repository**: A local project with a corresponding remote source and a working state (clean or dirty).
+- **Remote Change Status**: The result of checking whether a repository is behind its remote source.
+- **Pull Result**: Outcome of an update attempt, including status, timing, and any error details.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can update all eligible repositories in a 20-repository workspace in under 5 minutes when no conflicts occur.
+- **SC-002**: 100% of repositories in scope are reported as updated, skipped, or failed in the final summary.
+- **SC-003**: 95% of pull runs in clean workspaces complete without requiring user intervention.
+- **SC-004**: Users can identify the reason for any failure within 30 seconds by reading the command output.

--- a/specs/025-pull-command/tasks.md
+++ b/specs/025-pull-command/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Pull Command
+
+**Input**: Design documents from `/specs/025-pull-command/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Integration tests are required by the feature specification.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [X] T001 Create pull command file stub in repos/arashi/src/commands/pull.ts
+- [X] T002 Add pull command registration in repos/arashi/src/commands/index.ts
+- [X] T003 [P] Create integration test scaffold in repos/arashi/tests/integration/pull.test.ts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+- [X] T004 Define pull result types and status enums in repos/arashi/src/lib/pull-types.ts
+- [X] T005 [P] Add workspace config load helper for repositories in repos/arashi/src/lib/config.ts
+- [X] T006 [P] Implement repository filtering helper for --only in repos/arashi/src/lib/repo-filter.ts
+- [X] T007 [P] Implement remote change detection helper in repos/arashi/src/lib/git-remote.ts
+- [X] T008 Implement pull execution and rollback helper in repos/arashi/src/lib/pull-runner.ts
+- [X] T009 Implement progress and timing output helpers in repos/arashi/src/lib/pull-output.ts
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Update All Eligible Repositories (Priority: P1) 🎯 MVP
+
+**Goal**: Update all eligible repositories and report success or manual-update on conflict/error.
+
+**Independent Test**: Run the pull command in a workspace with remote changes and verify each eligible repository is updated or reported as manual-update with rollback.
+
+### Tests for User Story 1
+
+- [X] T010 [US1] Add integration test for successful multi-repo pull in repos/arashi/tests/integration/pull.test.ts
+- [X] T011 [US1] Add integration test for dirty repo rollback/manual-update in repos/arashi/tests/integration/pull.test.ts
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement core orchestration (load config, detect remote changes, invoke pull runner) in repos/arashi/src/commands/pull.ts
+- [X] T013 [US1] Implement summary reporting and non-zero exit handling in repos/arashi/src/commands/pull.ts
+
+**Checkpoint**: User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Targeted Pulls (Priority: P2)
+
+**Goal**: Allow users to limit the pull to a subset of repositories and skip those without remote changes.
+
+**Independent Test**: Run with --only filters and verify only those repositories are processed and no-change repos are skipped with a clear status.
+
+### Tests for User Story 2
+
+- [X] T014 [US2] Add integration test for --only filtering behavior in repos/arashi/tests/integration/pull.test.ts
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Implement --only flag parsing and filtering in repos/arashi/src/commands/pull.ts
+- [X] T016 [US2] Implement skip/report flow for repositories with no remote changes in repos/arashi/src/commands/pull.ts
+
+**Checkpoint**: User Stories 1 and 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Clear Progress and Diagnostics (Priority: P3)
+
+**Goal**: Provide progress, timing, and verbose diagnostics for each repository operation.
+
+**Independent Test**: Run in verbose and non-verbose modes and verify progress indicators, timing output, and full command output for verbose mode.
+
+### Tests for User Story 3
+
+- [X] T017 [US3] Add integration test for verbose output mode in repos/arashi/tests/integration/pull.test.ts
+- [X] T018 [US3] Add integration test for per-repo timing output in repos/arashi/tests/integration/pull.test.ts
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Implement progress indicators and per-repo timing in repos/arashi/src/commands/pull.ts
+- [X] T020 [US3] Implement verbose output plumbing in repos/arashi/src/commands/pull.ts
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T021 Add integration test for timeout/failure summary in repos/arashi/tests/integration/pull.test.ts
+- [X] T022 Harden error and timeout messaging in repos/arashi/src/commands/pull.ts
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational phase completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Starts after Foundational (Phase 2) - provides core pull flow
+- **User Story 2 (P2)**: Starts after US1 for shared orchestration reuse
+- **User Story 3 (P3)**: Starts after US1 for shared orchestration reuse
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Core orchestration before output refinements
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T005, T006, T007 can run in parallel
+- Tests within a user story can be parallelized by scenario focus
+- US2 and US3 can proceed in parallel after US1 core is stable
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Run scenario-specific tests in parallel:
+Task: "Add integration test for successful multi-repo pull in repos/arashi/tests/integration/pull.test.ts"
+Task: "Add integration test for dirty repo rollback/manual-update in repos/arashi/tests/integration/pull.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate User Story 1 independently
+
+### Incremental Delivery
+
+1. Add User Story 1 → Test independently
+2. Add User Story 2 → Test independently
+3. Add User Story 3 → Test independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable


### PR DESCRIPTION
## Summary
- add pull command specification, plan, and task breakdown
- include contracts, data model, and quickstart guidance
- update agent tech stack metadata for pull command

Related: https://github.com/corwinm/arashi-arashi/issues/60