### PR TITLE
specs: add create dry-run spec artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bower_components
 .lock-wscript
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
+build/
 build/Release
 
 # Dependency directories
@@ -157,4 +158,3 @@ Thumbs.db
 
 # Arashi repos
 repos/
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config-mgmt/
 - TypeScript 5.9 with Bun (latest stable) + commander, chalk, ora, @inquirer/prompts (026-sync-command)
 - File system (`.arashi/config.json`, git metadata) (026-sync-command)
 - File system (`.arashi/config.json`, `.arashi/hooks/`, git worktree metadata) (027-rework-hooks)
+- N/A (filesystem and git metadata only) (028-fix-create-dry-run)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -93,9 +94,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 028-fix-create-dry-run: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 - 027-rework-hooks: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 - 026-sync-command: Added TypeScript 5.9 with Bun (latest stable) + commander, chalk, ora, @inquirer/prompts
-- 025-pull-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/028-fix-create-dry-run/checklists/requirements.md
+++ b/specs/028-fix-create-dry-run/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Fix create --dry-run
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-08
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/028-fix-create-dry-run/contracts/create-dry-run.openapi.yaml
+++ b/specs/028-fix-create-dry-run/contracts/create-dry-run.openapi.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.3
+info:
+  title: Create Dry-Run Plan
+  version: 1.0.0
+  description: Conceptual contract for the create dry-run planning output.
+paths:
+  /create/dry-run:
+    post:
+      summary: Generate a dry-run plan for worktree creation
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Inputs equivalent to the create command.
+              additionalProperties: true
+      responses:
+        "200":
+          description: Dry-run plan generated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DryRunOutcome"
+        "409":
+          description: Blocking conflicts found in dry-run plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DryRunOutcome"
+components:
+  schemas:
+    PlannedWorktree:
+      type: object
+      properties:
+        repositoryName:
+          type: string
+        worktreePath:
+          type: string
+        branchName:
+          type: string
+        planStatus:
+          type: string
+          enum: [actionable, blocked]
+      required: [repositoryName, worktreePath, branchName, planStatus]
+    Conflict:
+      type: object
+      properties:
+        conflictType:
+          type: string
+          enum: [path_exists, branch_exists, permission_issue, invalid_configuration]
+        scope:
+          type: string
+        message:
+          type: string
+        blocking:
+          type: boolean
+      required: [conflictType, scope, message, blocking]
+    DryRunOutcome:
+      type: object
+      properties:
+        overallStatus:
+          type: string
+          enum: [actionable, blocked]
+        plannedWorktrees:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlannedWorktree"
+        conflicts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Conflict"
+        summaryCounts:
+          type: object
+          properties:
+            plannedTotal:
+              type: integer
+            conflictTotal:
+              type: integer
+          required: [plannedTotal, conflictTotal]
+      required: [overallStatus, plannedWorktrees, conflicts, summaryCounts]

--- a/specs/028-fix-create-dry-run/data-model.md
+++ b/specs/028-fix-create-dry-run/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Fix create --dry-run
+
+## Entities
+
+### Planned Worktree
+
+- **Represents**: A proposed worktree and branch that would be created in a real run.
+- **Fields**:
+  - **Repository Name**: Identifies the repository the worktree belongs to.
+  - **Worktree Path**: Target path for the worktree.
+  - **Branch Name**: Target branch to be created or used.
+  - **Plan Status**: Actionable or blocked for this item.
+- **Validation Rules**:
+  - Worktree Path and Branch Name must be non-empty.
+  - Repository Name must match a configured repository.
+
+### Conflict
+
+- **Represents**: A detected issue that would prevent creation.
+- **Fields**:
+  - **Conflict Type**: Existing path, existing branch, permission issue, or invalid configuration.
+  - **Scope**: Repository and target (path or branch) the conflict applies to.
+  - **Message**: Human-readable explanation.
+  - **Blocking**: Indicates whether the conflict blocks creation.
+- **Validation Rules**:
+  - Conflict Type and Scope must be present.
+
+### Dry-run Outcome
+
+- **Represents**: Summary of the dry-run result.
+- **Fields**:
+  - **Overall Status**: Actionable or blocked.
+  - **Planned Worktrees**: Collection of Planned Worktree entities.
+  - **Conflicts**: Collection of Conflict entities.
+  - **Summary Counts**: Totals for planned items and conflicts.
+- **Validation Rules**:
+  - Overall Status must reflect conflicts marked as blocking.
+
+## Relationships
+
+- A Dry-run Outcome includes zero or more Planned Worktrees.
+- A Dry-run Outcome includes zero or more Conflicts.
+- Conflicts may reference a Planned Worktree by shared repository or target values.

--- a/specs/028-fix-create-dry-run/plan.md
+++ b/specs/028-fix-create-dry-run/plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan: Fix create --dry-run
+
+**Branch**: `028-fix-create-dry-run` | **Date**: 2026-02-08 | **Spec**: `specs/028-fix-create-dry-run/spec.md`
+**Input**: Feature specification from `specs/028-fix-create-dry-run/spec.md`
+
+## Summary
+
+Ensure `create --dry-run` produces a non-mutating, accurate plan of worktrees/branches and conflicts, with a clear actionable vs blocked outcome.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9  
+**Primary Dependencies**: Bun runtime, commander, chalk, ora, @inquirer/prompts  
+**Storage**: N/A (filesystem and git metadata only)  
+**Testing**: Bun test runner  
+**Target Platform**: macOS, Linux, Windows (cross-platform CLI)  
+**Project Type**: single (CLI library + command entry)  
+**Performance Goals**: Dry-run completes under 3 seconds for up to 10 repositories and 50 planned worktrees  
+**Constraints**: No side effects; output must match real create plan; cross-platform path handling  
+**Scale/Scope**: Workspace with up to 10 repositories and 50 planned worktrees
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Single-file executable maintained (no new runtime deps) - Pass
+- Automatic worktree management preserved - Pass
+- Error recovery & rollback respected (dry-run is non-mutating) - Pass
+- User-centric output maintained (clear plan + conflicts) - Pass
+- Minimalist configuration preserved - Pass
+- Cross-platform compatibility maintained - Pass
+- Test coverage >80% achievable with added tests - Pass
+- Semantic versioning unaffected (bug fix) - Pass
+- Hook system unaffected - Pass
+- Performance standards met (dry-run under 3 seconds) - Pass
+
+**Post-Design Re-check**: Pass (no design changes affecting constitution)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-fix-create-dry-run/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── src/
+│   ├── index.ts
+│   └── types.ts
+└── tests/
+```
+
+**Structure Decision**: Single CLI project; implementation will land in `repos/arashi/src/` with tests in `repos/arashi/tests/`.

--- a/specs/028-fix-create-dry-run/quickstart.md
+++ b/specs/028-fix-create-dry-run/quickstart.md
@@ -1,0 +1,17 @@
+# Quickstart: Fix create --dry-run
+
+## Goal
+
+Validate that `create --dry-run` previews planned worktrees and conflicts without making changes.
+
+## Steps
+
+1. From a configured workspace, run the dry-run command with the same inputs you would use for create.
+2. Review the output to confirm it lists planned worktrees/branches, conflicts, and the actionable/blocked status.
+3. Verify no worktrees or branches were created by checking the workspace state.
+4. Optionally run a real create in a disposable test workspace and confirm the plan matches the dry-run output.
+
+## Expected Results
+
+- The output clearly indicates whether the plan is actionable or blocked.
+- No filesystem or git state changes occur during dry-run.

--- a/specs/028-fix-create-dry-run/research.md
+++ b/specs/028-fix-create-dry-run/research.md
@@ -1,0 +1,18 @@
+# Research: Fix create --dry-run
+
+**Date**: 2026-02-08
+**Context**: Ensure dry-run behavior matches create planning without side effects.
+
+## Decisions
+
+- **Decision**: Dry-run uses the same inputs and planning rules as real create.
+  **Rationale**: Guarantees output accuracy and prevents drift between preview and execution.
+  **Alternatives considered**: A separate dry-run-only planner; rejected due to divergence risk.
+
+- **Decision**: No new dependencies or configuration required.
+  **Rationale**: Preserves single-file executable constraints and minimalist configuration.
+  **Alternatives considered**: Introducing a new formatting or validation library; rejected as unnecessary.
+
+- **Decision**: Conflicts are treated as blocking with a clear blocked outcome while still listing the plan.
+  **Rationale**: Aligns with user expectation to resolve issues before running create.
+  **Alternatives considered**: Partial success with implicit skipping; rejected due to ambiguity.

--- a/specs/028-fix-create-dry-run/spec.md
+++ b/specs/028-fix-create-dry-run/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Fix create --dry-run
+
+**Feature Branch**: `028-fix-create-dry-run`  
+**Created**: 2026-02-08  
+**Status**: Draft  
+**Input**: User description: "https://github.com/corwinm/arashi-arashi/issues/65 (Bug: create --dry-run doesn't work)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preview planned changes (Priority: P1)
+
+As a CLI user, I want `create --dry-run` to show what would be created so I can validate the plan before making changes.
+
+**Why this priority**: This is the core value of dry-run and prevents unintended changes.
+
+**Independent Test**: Run `create --dry-run` in a workspace with valid inputs and verify the output lists planned worktrees/branches while the filesystem and git state remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid workspace configuration and no conflicting worktrees/branches, **When** I run `create --dry-run`, **Then** it lists all planned worktrees/branches and does not create any.
+2. **Given** a valid workspace configuration, **When** I run `create --dry-run`, **Then** the reported plan matches the plan that a real `create` run would execute for the same inputs.
+
+---
+
+### User Story 2 - Surface blocking conflicts (Priority: P2)
+
+As a CLI user, I want `create --dry-run` to warn me about conflicts that would prevent creation so I can resolve them before a real run.
+
+**Why this priority**: Early conflict visibility avoids failed runs and wasted time.
+
+**Independent Test**: Run `create --dry-run` in a workspace with known conflicts (existing worktree path or branch) and confirm the output includes those conflicts without making changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a target worktree path already exists, **When** I run `create --dry-run`, **Then** the output flags the path conflict and no changes are made.
+2. **Given** a target branch already exists, **When** I run `create --dry-run`, **Then** the output flags the branch conflict and no changes are made.
+
+---
+
+### User Story 3 - Understand dry-run outcomes (Priority: P3)
+
+As a CLI user, I want a clear indication of whether the dry-run plan is actionable so I know if it is safe to proceed.
+
+**Why this priority**: Users need a quick decision signal without parsing details.
+
+**Independent Test**: Run `create --dry-run` in both clean and conflicting scenarios and verify the output includes an actionable or blocked status with no changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a conflict-free plan, **When** I run `create --dry-run`, **Then** the output indicates the plan can proceed.
+2. **Given** any blocking conflict, **When** I run `create --dry-run`, **Then** the output indicates the plan is blocked.
+
+---
+
+### Edge Cases
+
+- What happens when the workspace configuration is missing or invalid?
+- How does the system handle a partially existing worktree (directory exists but is not a worktree)?
+- What happens when multiple conflicts exist across repositories?
+- How does the system handle insufficient permissions to inspect the target paths?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST perform a dry-run that makes no changes to worktrees, branches, or the filesystem.
+- **FR-002**: System MUST list every worktree and branch that would be created for the given inputs.
+- **FR-003**: System MUST identify and report conflicts that would block creation (e.g., existing target paths or branches).
+- **FR-004**: System MUST indicate whether the overall plan is actionable or blocked.
+- **FR-005**: System MUST ensure the dry-run plan aligns with the real create behavior for the same inputs.
+- **FR-006**: System MUST return an error outcome for dry-runs with blocking conflicts while still making no changes.
+
+### Key Entities *(include if feature involves data)*
+
+- **Planned Worktree**: A proposed worktree location and branch name that would be created in a real run.
+- **Conflict**: A detected condition that would prevent creation, including existing paths or branches.
+- **Dry-run Outcome**: A summary indicating whether the plan is actionable or blocked.
+
+## Assumptions
+
+- Dry-run uses the same inputs and configuration as a normal create command.
+- Output is displayed in a human-readable form suitable for quick review.
+- Dry-run never prompts for additional input beyond what create already accepts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After any `create --dry-run`, zero new worktrees or branches exist compared to pre-run state.
+- **SC-002**: In a test suite of at least 10 scenarios, the dry-run plan matches the real create plan 100% of the time.
+- **SC-003**: 95% of users can determine whether a plan is actionable from the dry-run output without additional guidance.
+- **SC-004**: Dry-run completes in under 3 seconds for a workspace with up to 10 repositories and 50 planned worktrees.

--- a/specs/028-fix-create-dry-run/tasks.md
+++ b/specs/028-fix-create-dry-run/tasks.md
@@ -1,0 +1,149 @@
+---
+
+description: "Task list for fix create --dry-run"
+---
+
+# Tasks: Fix create --dry-run
+
+**Input**: Design documents from `specs/028-fix-create-dry-run/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Not explicitly requested in the specification; no test tasks included.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing command wiring and entry points
+
+- [x] T001 Review dry-run option wiring in `repos/arashi/src/commands/create.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core dry-run planning and non-mutating behavior shared by all stories
+
+- [x] T002 Add dry-run planning types (PlannedWorktree, Conflict, DryRunOutcome) in `repos/arashi/src/core/worktree.ts`
+- [x] T003 Implement non-mutating plan builder using existing path calculation in `repos/arashi/src/core/worktree.ts`
+- [x] T004 Gate hook execution and git mutations behind dry-run checks in `repos/arashi/src/core/worktree.ts`
+
+**Checkpoint**: Dry-run can compute a plan without side effects
+
+---
+
+## Phase 3: User Story 1 - Preview planned changes (Priority: P1) 🎯 MVP
+
+**Goal**: Show planned worktrees/branches without making changes.
+
+**Independent Test**: Run `create --dry-run` and verify listed worktrees/branches match a real create plan while state remains unchanged.
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Expose planned worktree list from dry-run summary in `repos/arashi/src/core/worktree.ts`
+- [x] T006 [US1] Render planned worktrees/branches in dry-run output in `repos/arashi/src/commands/create.ts`
+
+**Checkpoint**: User Story 1 is fully functional and independently testable
+
+---
+
+## Phase 4: User Story 2 - Surface blocking conflicts (Priority: P2)
+
+**Goal**: Report conflicts that would block creation in dry-run output.
+
+**Independent Test**: Run `create --dry-run` with an existing worktree path or branch and verify conflicts are listed without changes.
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] Attach conflict details to dry-run outcome in `repos/arashi/src/core/worktree.ts`
+- [x] T008 [US2] Render conflict warnings in dry-run output in `repos/arashi/src/commands/create.ts`
+
+**Checkpoint**: User Story 2 is fully functional and independently testable
+
+---
+
+## Phase 5: User Story 3 - Understand dry-run outcomes (Priority: P3)
+
+**Goal**: Indicate whether the dry-run plan is actionable or blocked.
+
+**Independent Test**: Run `create --dry-run` in clean and conflicting scenarios and verify actionable/blocked status.
+
+### Implementation for User Story 3
+
+- [x] T009 [US3] Add actionable/blocked status summary in `repos/arashi/src/commands/create.ts`
+- [x] T010 [US3] Return blocked outcome exit code for dry-run conflicts in `repos/arashi/src/commands/create.ts`
+
+**Checkpoint**: User Story 3 is fully functional and independently testable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and validation updates
+
+- [x] T011 [P] Update CLI documentation for dry-run behavior in `repos/arashi/README.md`
+- [x] T012 [P] Validate quickstart steps and adjust wording in `specs/028-fix-create-dry-run/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3-5)**: Depend on Foundational phase completion
+- **Polish (Phase 6)**: Depends on desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependencies on other stories
+- **User Story 2 (P2)**: Can start after Foundational - independent of US1
+- **User Story 3 (P3)**: Can start after Foundational - independent of US1/US2
+
+### Parallel Opportunities
+
+- T011 and T012 can run in parallel with each other
+- User Story phases can be worked in parallel after Foundational, but avoid simultaneous edits to `repos/arashi/src/commands/create.ts`
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Work in parallel on separate files:
+Task: "Attach conflict details to dry-run outcome in repos/arashi/src/core/worktree.ts"
+Task: "Update CLI documentation for dry-run behavior in repos/arashi/README.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate dry-run preview output and no side effects
+
+### Incremental Delivery
+
+1. Add User Story 1 → Validate preview output
+2. Add User Story 2 → Validate conflict reporting
+3. Add User Story 3 → Validate actionable/blocked status
+4. Finish polish tasks
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- Each user story should be independently completable and testable
+- Avoid simultaneous edits to `repos/arashi/src/commands/create.ts` across stories


### PR DESCRIPTION
## Summary
- add spec, plan, tasks, and research for create --dry-run
- capture dry-run data model and contract outline
- update spec checklist and quickstart guidance

## Testing
- not run (docs/spec changes)

Relates to #65