### PR TITLE
specs: add oxlint/oxfmt setup artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ config-mgmt/
 - File system (`.arashi/config.json`, `.arashi/hooks/`, git worktree metadata) (027-rework-hooks)
 - N/A (filesystem and git metadata only) (028-fix-create-dry-run)
 - Filesystem workspace configuration (`.arashi/config.json`) and repository setup scripts/hooks (029-implement-setup-command)
+- TypeScript 5.9 with Bun runtime + Oxlint, Oxfmt, Bun, GitHub Actions CI (030-setup-oxlint-oxfmt)
+- Repository configuration files and source files on filesystem (no new persistent store) (030-setup-oxlint-oxfmt)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -95,9 +97,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 030-setup-oxlint-oxfmt: Added TypeScript 5.9 with Bun runtime + Oxlint, Oxfmt, Bun, GitHub Actions CI
 - 029-implement-setup-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 - 028-fix-create-dry-run: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
-- 027-rework-hooks: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/030-setup-oxlint-oxfmt/checklists/requirements.md
+++ b/specs/030-setup-oxlint-oxfmt/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Linter and Formatter Setup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1: All checklist items pass; no spec revisions required.

--- a/specs/030-setup-oxlint-oxfmt/contracts/quality-checks.openapi.yaml
+++ b/specs/030-setup-oxlint-oxfmt/contracts/quality-checks.openapi.yaml
@@ -1,0 +1,164 @@
+openapi: 3.0.3
+info:
+  title: Repository Quality Checks Contract
+  version: 1.0.0
+  description: Conceptual contract for linting, formatting, and pull request quality validation.
+paths:
+  /quality/lint:
+    post:
+      summary: Run repository lint checks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QualityCheckRequest"
+      responses:
+        "200":
+          description: Lint check completed with no blocking issues
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityCheckRun"
+        "422":
+          description: Lint check failed due to violations
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityCheckRun"
+  /quality/format:
+    post:
+      summary: Run repository format checks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QualityCheckRequest"
+      responses:
+        "200":
+          description: Format check completed with compliant formatting
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityCheckRun"
+        "422":
+          description: Format check failed due to non-compliant files
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityCheckRun"
+  /quality/validate:
+    post:
+      summary: Evaluate pull request quality gate from lint and format checks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidationRequest"
+      responses:
+        "200":
+          description: Pull request quality gate passes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationOutcome"
+        "422":
+          description: Pull request quality gate fails
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationOutcome"
+components:
+  schemas:
+    QualityCheckRequest:
+      type: object
+      properties:
+        scope:
+          type: string
+          enum: [full-repository, changed-files]
+          description: Scope to evaluate during the check run.
+        files:
+          type: array
+          items:
+            type: string
+          description: Optional explicit file list when using changed-files scope.
+      additionalProperties: false
+    QualityIssue:
+      type: object
+      properties:
+        filePath:
+          type: string
+        line:
+          type: integer
+          minimum: 1
+        column:
+          type: integer
+          minimum: 1
+        category:
+          type: string
+          description: Lint rule category or formatting classification.
+        message:
+          type: string
+      required: [filePath, category, message]
+    QualityCheckRun:
+      type: object
+      properties:
+        runId:
+          type: string
+        checkType:
+          type: string
+          enum: [lint, format]
+        scope:
+          type: string
+          enum: [full-repository, changed-files]
+        status:
+          type: string
+          enum: [passed, failed]
+        durationMs:
+          type: integer
+          minimum: 0
+        issueCount:
+          type: integer
+          minimum: 0
+        issues:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityIssue"
+      required:
+        - runId
+        - checkType
+        - scope
+        - status
+        - durationMs
+        - issueCount
+        - issues
+    ValidationRequest:
+      type: object
+      properties:
+        pullRequestId:
+          type: string
+        lintRun:
+          $ref: "#/components/schemas/QualityCheckRun"
+        formatRun:
+          $ref: "#/components/schemas/QualityCheckRun"
+      required: [pullRequestId, lintRun, formatRun]
+      additionalProperties: false
+    ValidationOutcome:
+      type: object
+      properties:
+        pullRequestId:
+          type: string
+        lintStatus:
+          type: string
+          enum: [pass, fail]
+        formatStatus:
+          type: string
+          enum: [pass, fail]
+        overallStatus:
+          type: string
+          enum: [pass, fail]
+        failureSummary:
+          type: string
+      required: [pullRequestId, lintStatus, formatStatus, overallStatus]

--- a/specs/030-setup-oxlint-oxfmt/data-model.md
+++ b/specs/030-setup-oxlint-oxfmt/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Linter and Formatter Setup
+
+## Entities
+
+### Code Quality Rule Set
+
+- **Represents**: The approved linting and formatting standards used for local checks and pull request validation.
+- **Fields**:
+  - **Rule Set Name**: Human-readable identifier for the ruleset.
+  - **Lint Rule Profile**: Enabled lint categories and severity levels.
+  - **Format Rule Profile**: Canonical formatting style settings.
+  - **Ignore Patterns**: File and directory patterns excluded from checks.
+  - **Version Pin**: Tool version(s) used to ensure deterministic results.
+- **Validation Rules**:
+  - Lint and format profiles must be explicitly defined.
+  - Ignore patterns must not exclude primary source or test directories by default.
+  - Version pin must be present for deterministic local and CI behavior.
+
+### Quality Check Run
+
+- **Represents**: A single invocation of linting, formatting, or combined quality validation.
+- **Fields**:
+  - **Run ID**: Unique identifier for the check execution.
+  - **Run Scope**: Full repository or filtered file subset.
+  - **Check Type**: lint, format, or combined validation.
+  - **Started At**: Execution start timestamp.
+  - **Finished At**: Execution end timestamp.
+  - **Duration**: Total elapsed runtime.
+  - **Outcome**: passed or failed.
+  - **Issue Count**: Number of violations detected.
+  - **Issue Details**: File-level diagnostics including location and rule/category.
+- **Validation Rules**:
+  - Duration must be non-negative.
+  - Failed runs must contain at least one issue or execution error detail.
+  - Passed runs must not include blocking violations.
+
+### Validation Outcome
+
+- **Represents**: The merge-gating decision generated from pull request quality checks.
+- **Fields**:
+  - **Pull Request Identifier**: Unique pull request reference.
+  - **Lint Status**: pass or fail.
+  - **Format Status**: pass or fail.
+  - **Overall Gate Status**: pass or fail.
+  - **Failure Summary**: Contributor-facing explanation of what must be fixed.
+  - **Evaluated At**: Timestamp of decision.
+- **Validation Rules**:
+  - Overall Gate Status must be fail if either lint or format status is fail.
+  - Failure Summary is required whenever Overall Gate Status is fail.
+
+## Relationships
+
+- A Code Quality Rule Set governs many Quality Check Runs.
+- A Validation Outcome references one or more Quality Check Runs for the same pull request event.
+- A Validation Outcome consumes lint and format run outcomes to compute the final gate decision.
+
+## State Transitions
+
+- **Code Quality Rule Set**: drafted -> approved -> active -> revised.
+- **Quality Check Run**: queued -> running -> passed | failed.
+- **Validation Outcome**: pending -> evaluated -> pass | fail.

--- a/specs/030-setup-oxlint-oxfmt/plan.md
+++ b/specs/030-setup-oxlint-oxfmt/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Linter and Formatter Setup
+
+**Branch**: `030-setup-oxlint-oxfmt` | **Date**: 2026-02-09 | **Spec**: `specs/030-setup-oxlint-oxfmt/spec.md`
+**Input**: Feature specification from `specs/030-setup-oxlint-oxfmt/spec.md`
+
+## Summary
+
+Establish Oxlint and Oxfmt as the default code quality workflows for the Arashi repository, expose consistent contributor commands, and enforce these checks in pull request validation so non-compliant changes are blocked before merge.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 with Bun runtime  
+**Primary Dependencies**: Oxlint, Oxfmt, Bun, GitHub Actions CI  
+**Storage**: Repository configuration files and source files on filesystem (no new persistent store)  
+**Testing**: Bun test runner, plus lint and format validation checks in local and CI flows  
+**Target Platform**: macOS, Linux, and Windows contributors; Linux CI runners  
+**Project Type**: Single CLI project (`repos/arashi`)  
+**Performance Goals**: PR quality checks complete within 6 minutes p95; local changed-file quality checks complete within 60 seconds for typical changes  
+**Constraints**: Preserve existing contributor workflow, avoid formatting generated/vendor artifacts, keep local and CI outcomes deterministic, no breaking changes to user-facing CLI commands  
+**Scale/Scope**: Medium TypeScript CLI codebase with ongoing multi-contributor pull request activity
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Single-file executable distribution model unchanged (tooling affects development workflow only) - Pass
+- Automatic worktree coordination behavior untouched - Pass
+- Error recovery and rollback behavior untouched - Pass
+- User-centric interface upheld through clear lint/format feedback and remediation guidance - Pass
+- Minimalist configuration upheld by adding only essential quality configuration - Pass
+- Cross-platform compatibility preserved for local contributor tooling and CI validation - Pass
+- Test coverage principle supported by adding or updating tests with this feature - Pass
+- Semantic versioning impact is additive (`feat`) with no breaking change - Pass
+- Hook system compatibility preserved (no removal or behavioral change to hooks) - Pass
+- Performance standards respected through bounded check duration targets and parallelizable CI checks - Pass
+
+**Post-Design Re-check**: Pass (research, data model, contracts, and quickstart preserve all constitutional principles without exceptions)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-setup-oxlint-oxfmt/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── quality-checks.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── package.json
+├── oxlint.json
+├── .oxfmtrc.json
+├── src/
+├── tests/
+└── .github/
+    └── workflows/
+        └── ci.yml
+```
+
+**Structure Decision**: Keep implementation in `repos/arashi` and introduce quality-tool configuration at repository root while reusing existing source, test, and CI workflow locations.
+
+## Complexity Tracking
+
+No constitutional violations identified; no complexity exceptions required.

--- a/specs/030-setup-oxlint-oxfmt/quickstart.md
+++ b/specs/030-setup-oxlint-oxfmt/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Linter and Formatter Setup
+
+## Goal
+
+Enable contributors to run consistent lint and format checks locally and enforce the same standards in pull request validation.
+
+## Prerequisites
+
+1. The Arashi repository is available in `repos/arashi`.
+2. Project dependencies are installed.
+3. Contributor is working from the Arashi repository root.
+
+## Steps
+
+1. Configure repository-level lint and format rule files, including ignore patterns for generated or vendored artifacts.
+2. Add contributor-facing scripts for lint, lint auto-fix, format, and format check.
+3. Run lint and format checks locally on a sample change and confirm pass/fail diagnostics identify affected files.
+4. Trigger pull request validation and verify lint and format checks execute as required gates.
+5. Introduce an intentional lint and formatting violation and confirm pull request validation fails with actionable remediation guidance.
+6. Fix violations and confirm pull request validation returns to passing state.
+
+## Expected Results
+
+- Contributors can run one documented set of commands for local quality checks.
+- Lint and format checks consistently identify non-compliant files and issues.
+- Pull request validation blocks merge when lint or format checks fail.
+- Generated/vendor artifacts remain excluded from formatting and linting scope.

--- a/specs/030-setup-oxlint-oxfmt/research.md
+++ b/specs/030-setup-oxlint-oxfmt/research.md
@@ -1,0 +1,30 @@
+# Research: Linter and Formatter Setup
+
+**Date**: 2026-02-09
+**Context**: Define a low-friction rollout of Oxlint and Oxfmt for local contributor workflows and pull request quality gates in the Arashi repository.
+
+## Decisions
+
+- **Decision**: Adopt a phased lint strictness rollout, starting with high-signal categories and progressively tightening enforcement.
+  **Rationale**: This captures correctness issues quickly without overwhelming contributors with immediate style churn in an existing codebase.
+  **Alternatives considered**: Enforce all lint categories from day one; rejected due to likely large migration noise and blocked contributor throughput.
+
+- **Decision**: Provide explicit quality scripts for local and CI usage (`lint`, `lint:fix`, `lint:ci`, `format`, `format:check`) with consistent behavior.
+  **Rationale**: Clear command intent reduces ambiguity, aligns local and CI outcomes, and makes onboarding easier.
+  **Alternatives considered**: A single overloaded command; rejected because it mixes local and CI concerns and increases misuse risk.
+
+- **Decision**: Pin formatter and linter versions at repository level and run the same commands in CI as documented for contributors.
+  **Rationale**: Version pinning and shared command paths prevent local/CI drift and unexpected failures from upstream tool changes.
+  **Alternatives considered**: Always running latest tool versions in CI; rejected because non-deterministic upgrades can destabilize pull request validation.
+
+- **Decision**: Exclude generated, vendored, and transient artifacts through explicit ignore patterns in formatting and linting configuration.
+  **Rationale**: This avoids noisy rewrites and preserves stable generated outputs while keeping source files consistently formatted.
+  **Alternatives considered**: Repo-wide formatting with no exclusions; rejected because it risks touching non-source artifacts and creating unnecessary review noise.
+
+- **Decision**: Run lint and format checks as required pull request gates with actionable failure output.
+  **Rationale**: Hard fail quality gates ensure merge consistency, while clear file-level diagnostics keep remediation fast for contributors.
+  **Alternatives considered**: Warning-only CI checks; rejected because non-blocking checks allow standards drift and reduce enforcement effectiveness.
+
+- **Decision**: Keep full-repository checks as the default enforcement baseline and optionally add changed-file acceleration later if runtime targets are missed.
+  **Rationale**: Full checks maximize confidence in early adoption and reduce the chance of hidden legacy violations slipping through.
+  **Alternatives considered**: Changed-files-only checks by default; rejected for initial rollout because it may miss pre-existing issues affected by new rules.

--- a/specs/030-setup-oxlint-oxfmt/spec.md
+++ b/specs/030-setup-oxlint-oxfmt/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Linter and Formatter Setup
+
+**Feature Branch**: `030-setup-oxlint-oxfmt`  
+**Created**: 2026-02-09  
+**Status**: Draft  
+**Input**: User description: "https://github.com/corwinm/arashi-arashi/issues/62"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run consistent code quality checks (Priority: P1)
+
+As a contributor, I can run standard linting and formatting checks for the Arashi repository so I can catch code quality issues before opening a pull request.
+
+**Why this priority**: Reliable local quality checks are the core value of this feature and prevent avoidable review and CI failures.
+
+**Independent Test**: Can be fully tested by running the repository quality-check commands in a sample change set and verifying lint and format results are reported consistently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor has modified source files, **When** they run the linting check, **Then** they receive clear pass/fail output for code quality violations.
+2. **Given** a contributor has files with style deviations, **When** they run the formatting command, **Then** style issues are corrected or clearly reported so the contributor can resolve them.
+
+---
+
+### User Story 2 - Enforce standards in pull request validation (Priority: P2)
+
+As a maintainer, I can rely on automated lint and format validation during pull request checks so only code that meets repository standards is merged.
+
+**Why this priority**: Automated enforcement reduces manual review burden and keeps repository quality predictable, but depends on local tooling being usable first.
+
+**Independent Test**: Can be fully tested by triggering pull request validation with both compliant and non-compliant changes and verifying the expected pass/fail outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request with code that meets repository style and lint standards, **When** automated validation runs, **Then** the quality checks pass.
+2. **Given** a pull request with lint or formatting violations, **When** automated validation runs, **Then** the quality checks fail and indicate that corrections are required before merge.
+
+---
+
+### User Story 3 - Onboard contributors quickly (Priority: P3)
+
+As a new contributor, I can follow repository guidance to run linting and formatting checks without guessing commands so I can contribute with minimal setup friction.
+
+**Why this priority**: Good onboarding improves contributor experience and consistency, but remains secondary to having the checks and enforcement in place.
+
+**Independent Test**: Can be fully tested by having a contributor unfamiliar with the repository follow documented steps and complete lint and format checks successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new contributor cloned the repository, **When** they follow the documented workflow for quality checks, **Then** they can run lint and format checks without additional tribal knowledge.
+2. **Given** a contributor encounters a quality-check failure, **When** they consult the documented guidance, **Then** they can identify required remediation steps.
+
+### Edge Cases
+
+- The repository contains generated, vendored, or external files that should not be reformatted.
+- A file passes linting but still fails formatting, or vice versa.
+- Contributors run checks from different entry points (for example full repo vs changed files) and receive inconsistent outcomes.
+- Quality checks are run in an environment with missing prerequisites.
+- Existing legacy files trigger many violations on first adoption and could block unrelated contributions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a standard linting workflow for repository source files.
+- **FR-002**: The system MUST provide a standard formatting workflow for repository source files.
+- **FR-003**: The system MUST define and apply a single set of linting rules for all contributors.
+- **FR-004**: The system MUST define and apply a single set of formatting rules for all contributors.
+- **FR-005**: The system MUST present linting results in a way that identifies failing files and the associated issues.
+- **FR-006**: The system MUST present formatting results in a way that identifies changed or non-compliant files.
+- **FR-007**: The system MUST expose repository-level commands or documented entry points so contributors can run lint and format workflows locally.
+- **FR-008**: The system MUST include automated pull request validation that enforces lint and format standards before merge.
+- **FR-009**: The system MUST fail validation when linting or formatting requirements are not met.
+- **FR-010**: The system MUST document contributor-facing instructions for running quality checks and remediating failures.
+
+### Key Entities *(include if feature involves data)*
+
+- **Code Quality Rule Set**: The repository-approved linting and formatting standards that define valid source code quality.
+- **Quality Check Run**: A single linting or formatting execution event with scope, outcome, and issue details.
+- **Validation Outcome**: The pass/fail result used to determine whether a contribution satisfies repository quality gates.
+
+### Assumptions
+
+- The feature applies to the Arashi repository as referenced in the issue description.
+- Existing repository automation can execute quality checks during pull request validation.
+- Contributors are expected to run quality checks before opening or updating pull requests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of pull requests are evaluated by lint and format validation before merge eligibility is granted.
+- **SC-002**: At least 95% of contributors can run repository quality checks successfully on first attempt using documented instructions.
+- **SC-003**: In validation testing, 100% of intentionally non-compliant sample changes are rejected by automated quality checks.
+- **SC-004**: Within one release cycle of adoption, formatting-related review comments decrease by at least 50% compared with the prior cycle.

--- a/specs/030-setup-oxlint-oxfmt/tasks.md
+++ b/specs/030-setup-oxlint-oxfmt/tasks.md
@@ -1,0 +1,163 @@
+# Tasks: Linter and Formatter Setup
+
+**Input**: Design documents from `/specs/030-setup-oxlint-oxfmt/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Introduce baseline tooling files and dependency pins in the implementation repository.
+
+- [ ] T001 Add pinned Oxlint and Oxfmt dev dependencies in `repos/arashi/package.json`
+- [ ] T002 Create baseline lint configuration file in `repos/arashi/oxlint.json`
+- [ ] T003 Create baseline formatter configuration file in `repos/arashi/.oxfmtrc.json`
+- [ ] T004 [P] Add quality tooling defaults and exclusions in `repos/arashi/.gitignore`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared quality command entry points and baseline behavior required by all stories.
+
+**⚠️ CRITICAL**: No user story work should start until this phase is complete.
+
+- [ ] T005 Define repository quality scripts (`lint`, `lint:fix`, `lint:ci`, `format`, `format:check`) in `repos/arashi/package.json`
+- [ ] T006 [P] Align lint output format and severity defaults for actionable diagnostics in `repos/arashi/oxlint.json`
+- [ ] T007 [P] Define formatter ignore patterns for generated/vendor/transient files in `repos/arashi/.oxfmtrc.json`
+
+**Checkpoint**: Foundation ready - user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 - Run consistent code quality checks (Priority: P1) 🎯 MVP
+
+**Goal**: Contributors can run standard local lint and format workflows with predictable results.
+
+**Independent Test**: From `repos/arashi/`, run `bun run lint` and `bun run format:check` on a sample change; verify both commands return clear pass/fail diagnostics and identify affected files.
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Configure initial lint rule profile rollout strategy in `repos/arashi/oxlint.json`
+- [ ] T009 [US1] Configure canonical formatting style rules in `repos/arashi/.oxfmtrc.json`
+- [ ] T010 [US1] Add optional local autofix flow for lint and formatting in `repos/arashi/package.json`
+- [ ] T011 [P] [US1] Add a changed-files quality command for faster local feedback in `repos/arashi/package.json`
+- [ ] T012 [US1] Verify local quality command behavior against intentional violations via `repos/arashi/package.json`
+
+**Checkpoint**: User Story 1 is independently functional and testable.
+
+---
+
+## Phase 4: User Story 2 - Enforce standards in pull request validation (Priority: P2)
+
+**Goal**: Pull requests are blocked when lint or format requirements are not met.
+
+**Independent Test**: Trigger CI for one compliant and one non-compliant pull request and confirm required quality checks pass/fail correctly before merge eligibility.
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Add CI quality-check job scaffolding for lint and format validation in `repos/arashi/.github/workflows/ci.yml`
+- [ ] T014 [P] [US2] Add lint gate step using repository quality scripts in `repos/arashi/.github/workflows/ci.yml`
+- [ ] T015 [P] [US2] Add format gate step using repository quality scripts in `repos/arashi/.github/workflows/ci.yml`
+- [ ] T016 [US2] Configure CI failure messaging and final gate behavior in `repos/arashi/.github/workflows/ci.yml`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Onboard contributors quickly (Priority: P3)
+
+**Goal**: New contributors can discover and run quality workflows without tribal knowledge.
+
+**Independent Test**: A new contributor can follow documented instructions from a clean checkout and successfully run lint and format workflows, including remediation of one failing case.
+
+### Implementation for User Story 3
+
+- [ ] T017 [US3] Document local lint and format workflow commands in `repos/arashi/README.md`
+- [ ] T018 [US3] Document CI quality gate expectations and failure remediation in `repos/arashi/CONTRIBUTING.md`
+- [ ] T019 [P] [US3] Add troubleshooting guidance for common quality-check failures in `repos/arashi/docs/quality-checks.md`
+
+**Checkpoint**: All user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency checks and cross-story validation.
+
+- [ ] T020 [P] Reconcile quality command references across documentation in `repos/arashi/README.md`
+- [ ] T021 Run full project validation (`bun run lint`, `bun test`, `bun run build`) from `repos/arashi/package.json` and resolve findings in `repos/arashi/`
+- [ ] T022 Validate quickstart workflow end-to-end and update any drift in `specs/030-setup-oxlint-oxfmt/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) has no dependencies and starts immediately.
+- Foundational (Phase 2) depends on Setup and blocks all user stories.
+- User Story phases (Phases 3-5) depend on Foundational completion.
+- Polish (Phase 6) depends on completion of all selected user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Phase 2; no dependency on other stories.
+- **US2 (P2)**: Starts after Phase 2 and depends on US1 command availability.
+- **US3 (P3)**: Starts after Phase 2 and depends on finalized US1/US2 workflows for accurate documentation.
+
+### Dependency Graph
+
+- `US1 -> US2 -> US3`
+- `US1 -> US3`
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```bash
+# Parallelizable local workflow tasks
+Task T011: Add changed-files quality command in repos/arashi/package.json
+Task T008: Configure initial lint profile in repos/arashi/oxlint.json
+```
+
+### User Story 2
+
+```bash
+# Parallelizable CI gate steps after T013
+Task T014: Add lint gate step in repos/arashi/.github/workflows/ci.yml
+Task T015: Add format gate step in repos/arashi/.github/workflows/ci.yml
+```
+
+### User Story 3
+
+```bash
+# Parallelizable documentation additions
+Task T017: Update repos/arashi/README.md
+Task T019: Add repos/arashi/docs/quality-checks.md
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Complete Phase 1 and Phase 2.
+2. Deliver Phase 3 (US1) and validate local lint/format usability.
+3. Pause for MVP review before CI enforcement rollout.
+
+### Incremental Delivery
+
+1. Add local quality workflows (US1).
+2. Add pull request enforcement (US2).
+3. Add contributor onboarding docs (US3).
+4. Complete Polish phase for end-to-end consistency.
+
+### Parallel Team Strategy
+
+1. One contributor finalizes lint/format config (US1).
+2. One contributor implements CI gate steps after foundations are merged (US2).
+3. One contributor prepares docs once command/CI behavior stabilizes (US3).


### PR DESCRIPTION
## Summary
- add full feature-spec package for `030-setup-oxlint-oxfmt` (spec, plan, research, data model, contracts, quickstart, tasks, checklist)
- update `AGENTS.md` with the newly generated feature metadata from the spec pipeline
- capture the quality-check contract and rollout plan that implementation in `repos/arashi` follows

## Validation
- specs/docs only; no runtime/build changes in this repo

## Original Issue
- Related to #62
- Source: https://github.com/corwinm/arashi-arashi/issues/62