### PR TITLE
specs: add bare create command implementation artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ config-mgmt/
 - Filesystem workspace configuration (`.arashi/config.json`) and repository setup scripts/hooks (029-implement-setup-command)
 - TypeScript 5.9 with Bun runtime + Oxlint, Oxfmt, Bun, GitHub Actions CI (030-setup-oxlint-oxfmt)
 - Repository configuration files and source files on filesystem (no new persistent store) (030-setup-oxlint-oxfmt)
+- N/A (filesystem, git metadata, and repository refs only) (032-fix-bare-create-command)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -97,9 +98,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 032-fix-bare-create-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 - 030-setup-oxlint-oxfmt: Added TypeScript 5.9 with Bun runtime + Oxlint, Oxfmt, Bun, GitHub Actions CI
 - 029-implement-setup-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
-- 028-fix-create-dry-run: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/032-fix-bare-create-command/checklists/requirements.md
+++ b/specs/032-fix-bare-create-command/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Create Command from Bare Repository
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation result: pass (iteration 1). No spec updates required after checklist review.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/032-fix-bare-create-command/contracts/create-bare-context.openapi.yaml
+++ b/specs/032-fix-bare-create-command/contracts/create-bare-context.openapi.yaml
@@ -1,0 +1,180 @@
+openapi: 3.0.3
+info:
+  title: Arashi Create Command Context Contract
+  version: 1.0.0
+  description: >-
+    Contract for create command behavior when invoked from bare and non-bare
+    repository contexts.
+paths:
+  /create/validate-context:
+    post:
+      summary: Validate create invocation context
+      description: Determines executable context and configuration availability for a create request.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidateContextRequest'
+      responses:
+        '200':
+          description: Context resolved and request is executable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateContextResponse'
+        '400':
+          description: Request invalid or context cannot be resolved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /create/execute:
+    post:
+      summary: Execute coordinated create request
+      description: Creates coordinated worktrees after successful context validation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExecuteRequest'
+      responses:
+        '200':
+          description: Create request executed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateExecuteResponse'
+        '409':
+          description: Conflict prevents create execution and includes retry guidance.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Missing setup or unresolved configuration with actionable next step.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    ValidateContextRequest:
+      type: object
+      required:
+        - invocationPath
+        - branchName
+      properties:
+        invocationPath:
+          type: string
+          description: Absolute path where the create command was invoked.
+        branchName:
+          type: string
+          description: Requested branch/worktree name.
+        mode:
+          type: string
+          enum: [all, explicit, interactive]
+          default: all
+        selectedRepositories:
+          type: array
+          items:
+            type: string
+
+    ValidateContextResponse:
+      type: object
+      required:
+        - repositoryType
+        - workspaceRoot
+        - executionPath
+        - configResolved
+      properties:
+        repositoryType:
+          type: string
+          enum: [bare, non-bare]
+        workspaceRoot:
+          type: string
+        executionPath:
+          type: string
+        configResolved:
+          type: boolean
+        configSource:
+          type: string
+          enum: [local-file, repository-content]
+        guidance:
+          type: string
+          description: User-facing next step when validation fails or is partial.
+
+    CreateExecuteRequest:
+      type: object
+      required:
+        - branchName
+        - executionPath
+      properties:
+        branchName:
+          type: string
+        executionPath:
+          type: string
+        mode:
+          type: string
+          enum: [all, explicit, interactive]
+          default: all
+        selectedRepositories:
+          type: array
+          items:
+            type: string
+        dryRun:
+          type: boolean
+          default: false
+        hooksEnabled:
+          type: boolean
+          default: true
+
+    CreateExecuteResponse:
+      type: object
+      required:
+        - outcome
+        - rollbackApplied
+      properties:
+        outcome:
+          type: string
+          enum: [success, failure]
+        rollbackApplied:
+          type: boolean
+        createdWorktrees:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatedWorktree'
+        warnings:
+          type: array
+          items:
+            type: string
+        guidance:
+          type: string
+
+    CreatedWorktree:
+      type: object
+      required:
+        - repository
+        - path
+      properties:
+        repository:
+          type: string
+        path:
+          type: string
+
+    ErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+        - guidance
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        guidance:
+          type: string

--- a/specs/032-fix-bare-create-command/data-model.md
+++ b/specs/032-fix-bare-create-command/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Fix create command in bare repositories
+
+## Entities
+
+### Invocation Context
+
+- **Represents**: Where and how the user invoked the create command.
+- **Fields**:
+  - **Invocation Path**: Absolute path where command started.
+  - **Repository Type**: Bare or non-bare classification.
+  - **Workspace Root**: Resolved workspace base path used for config and repository resolution.
+  - **Execution Path**: Effective path used to run create orchestration.
+- **Validation Rules**:
+  - Invocation Path and Execution Path must be absolute and non-empty.
+  - Repository Type must be one of: bare, non-bare.
+  - Execution Path must resolve to a valid git working context before orchestration begins.
+
+### Workspace Configuration Source
+
+- **Represents**: How configuration is located for the current invocation.
+- **Fields**:
+  - **Source Type**: Local-file or repository-content.
+  - **Config Path**: Canonical config location (`.arashi/config.json`).
+  - **Resolution Status**: Resolved or missing.
+  - **Failure Reason**: Human-readable reason when unresolved.
+- **Validation Rules**:
+  - Source Type is required and must be explicit.
+  - Resolution Status must be resolved before repository discovery starts.
+  - Missing configuration must include a corrective guidance message.
+
+### Create Request
+
+- **Represents**: User-supplied request for coordinated worktree creation.
+- **Fields**:
+  - **Branch Name**: Requested branch/worktree name.
+  - **Repository Selection Mode**: All, explicit list, or interactive selection.
+  - **Behavior Flags**: Hook execution, progress visibility, dry-run, conflict strategy.
+- **Validation Rules**:
+  - Branch Name must satisfy existing branch naming rules.
+  - Explicit repository selections must map to configured repositories.
+
+### Create Execution Outcome
+
+- **Represents**: Final command result after context resolution and orchestration.
+- **Fields**:
+  - **Outcome Type**: Success, validation failure, or execution failure.
+  - **Created Worktrees**: List of repository/path pairs on success.
+  - **Conflict Details**: Any name/path conflicts detected.
+  - **Rollback Applied**: Whether rollback executed.
+  - **User Guidance**: Actionable next-step message on failure.
+- **Validation Rules**:
+  - Success outcomes must include at least one created worktree or an explicit no-op reason.
+  - Failures must include non-empty user guidance.
+  - Rollback Applied must be true when a partially completed operation fails.
+
+## Relationships
+
+- One **Invocation Context** resolves one **Workspace Configuration Source**.
+- One **Create Request** executes within one **Invocation Context**.
+- One **Create Request** produces one **Create Execution Outcome**.
+- **Create Execution Outcome** may reference multiple created worktree records and conflict records.

--- a/specs/032-fix-bare-create-command/plan.md
+++ b/specs/032-fix-bare-create-command/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Fix create command in bare repositories
+
+**Branch**: `032-fix-bare-create-command` | **Date**: 2026-02-09 | **Spec**: `specs/032-fix-bare-create-command/spec.md`
+**Input**: Feature specification from `specs/032-fix-bare-create-command/spec.md`
+
+## Summary
+
+Allow `arashi create <branch>` to succeed when invoked from a bare repository root by resolving workspace configuration in bare-repo context and executing create operations from a valid worktree context without changing behavior for normal worktree invocations.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9  
+**Primary Dependencies**: Bun runtime, commander, chalk, ora, @inquirer/prompts  
+**Storage**: N/A (filesystem, git metadata, and repository refs only)  
+**Testing**: Bun test runner (unit + integration)  
+**Target Platform**: macOS, Linux, Windows (cross-platform CLI)  
+**Project Type**: single (CLI + library modules)  
+**Performance Goals**: Create command start-up context resolution adds less than 1 second overhead for workspaces with up to 10 repositories  
+**Constraints**: Preserve rollback guarantees; preserve current create behavior in non-bare contexts; maintain clear user-facing errors for missing setup  
+**Scale/Scope**: Workspace with 1 main repository plus up to 10 configured child repositories
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Single-file executable maintained (no new runtime dependencies) - Pass
+- Automatic worktree management across configured repositories preserved - Pass
+- Error recovery and rollback behavior preserved for failed create runs - Pass
+- User-centric output preserved (clear progress and actionable errors) - Pass
+- Minimalist configuration preserved (`.arashi/config.json` remains canonical) - Pass
+- Cross-platform compatibility preserved (path and git behavior considerations included) - Pass
+- Test coverage target (>80%) feasible with added unit and integration tests - Pass
+- Semantic versioning impact is patch-level bug fix - Pass
+- Hook system behavior unchanged unless explicitly disabled by flags - Pass
+- Performance standards maintained (no material regression for create startup) - Pass
+
+**Post-Design Re-check**: Pass. Design artifacts add no constitutional violations and explicitly preserve rollback, hooks, cross-platform behavior, and testability.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/032-fix-bare-create-command/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── src/
+│   ├── commands/
+│   │   └── create.ts
+│   ├── lib/
+│   │   ├── config.ts
+│   │   └── git.ts
+│   └── core/
+│       └── worktree.ts
+└── tests/
+    ├── unit/
+    └── integration/
+```
+
+**Structure Decision**: Keep the existing single CLI project structure. Implement command/context resolution in `repos/arashi/src/commands/create.ts` and supporting config/git helpers in existing library modules, with regression coverage in `repos/arashi/tests/unit/` and `repos/arashi/tests/integration/`.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/032-fix-bare-create-command/quickstart.md
+++ b/specs/032-fix-bare-create-command/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Fix create command in bare repositories
+
+## Goal
+
+Verify that `arashi create <branch>` works from both bare repository roots and regular worktree directories, with clear guidance for missing setup.
+
+## Prerequisites
+
+1. A test workspace containing:
+   - one bare main repository,
+   - at least one non-bare worktree attached to that bare repository,
+   - `.arashi/config.json` available through workspace configuration.
+2. Arashi CLI built and runnable locally.
+
+## Validation Steps
+
+1. Run create from a regular worktree directory and capture baseline behavior/output.
+2. Run the same create request from the bare repository root.
+3. Confirm the bare-root run succeeds and creates equivalent worktree results.
+4. Run create from a bare repository where workspace configuration is not available.
+5. Confirm the command fails with actionable recovery guidance rather than an ambiguous internal error.
+6. Run a conflict case (existing branch/worktree name) from bare root and verify conflict reporting remains consistent.
+
+## Expected Results
+
+- Bare-root invocation no longer fails with a false local config-not-found error.
+- Non-bare invocation behavior remains unchanged.
+- Missing setup errors include specific next actions (for example, run `arashi init` from a checked-out worktree).
+- Conflict errors include a concrete retry path (for example, `--conflict REUSE_EXISTING` or using a new branch name).
+- Failure paths do not leave partial worktree artifacts.

--- a/specs/032-fix-bare-create-command/research.md
+++ b/specs/032-fix-bare-create-command/research.md
@@ -1,0 +1,30 @@
+# Research: Fix create command in bare repositories
+
+**Date**: 2026-02-09
+**Context**: Enable `create` to run from bare repository roots without false config-not-found failures and without regressing normal worktree behavior.
+
+## Decisions
+
+- **Decision**: Detect invocation context early and branch execution logic for bare vs non-bare repository entry points.
+  **Rationale**: The current failure path comes from assuming a checked-out working directory and local config file path. Explicit context detection avoids this invalid assumption.
+  **Alternatives considered**: Keep a single path that always reads local files from current directory; rejected because bare repositories do not expose checked-out workspace files.
+
+- **Decision**: Resolve workspace root for `create` using workspace discovery behavior already used by other commands, and only fall back to bare-repo specific lookup when local workspace discovery cannot succeed.
+  **Rationale**: Reuse of established behavior reduces regression risk and keeps non-bare command behavior unchanged.
+  **Alternatives considered**: Add a create-only configuration path flag; rejected because it increases user burden and conflicts with minimalist configuration principles.
+
+- **Decision**: For bare repository invocation, source configuration from repository content (default-branch view) when `.arashi/config.json` is not available as a local file.
+  **Rationale**: This satisfies the feature requirement that configuration remains usable from bare repositories and aligns with the workspace configuration being authoritative.
+  **Alternatives considered**: Require users to always run from an existing non-bare worktree; rejected because it does not solve the reported bug and weakens bare-repo support.
+
+- **Decision**: Run create operations in a valid non-bare worktree context associated with the target repository when invoked from bare root.
+  **Rationale**: Worktree creation and repository discovery logic depend on filesystem paths that represent checked-out content.
+  **Alternatives considered**: Perform all operations directly in bare root; rejected because repository discovery and relative-path semantics become ambiguous or invalid.
+
+- **Decision**: Preserve existing rollback semantics and conflict behavior unchanged.
+  **Rationale**: The issue is context resolution, not orchestration semantics; changing rollback/conflict behavior would expand scope and increase risk.
+  **Alternatives considered**: Introduce new partial-success modes for bare runs; rejected due to inconsistency and higher support cost.
+
+- **Decision**: Add targeted coverage for both success and failure flows specific to bare invocation.
+  **Rationale**: The regression is environment-specific; integration coverage is required to prevent reintroduction.
+  **Alternatives considered**: Unit-only tests; rejected because they would not validate end-to-end command behavior across repository contexts.

--- a/specs/032-fix-bare-create-command/spec.md
+++ b/specs/032-fix-bare-create-command/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Create Command from Bare Repository
+
+**Feature Branch**: `032-fix-bare-create-command`  
+**Created**: 2026-02-09  
+**Status**: Draft  
+**Input**: User description: "https://github.com/corwinm/arashi-arashi/issues/57"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run create from bare repo root (Priority: P1)
+
+As a developer working in a bare repository, I can run the create command from the repository root and it succeeds without requiring me to switch into an existing worktree first.
+
+**Why this priority**: This is the core reported failure and blocks the primary workflow for users who operate from bare repositories.
+
+**Independent Test**: In a bare repository with a valid workspace configuration, run the create command from the bare repo root and verify a new worktree is created successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bare repository with valid workspace configuration, **When** the user runs create from the bare repo root, **Then** the command completes successfully and creates the requested worktree.
+2. **Given** the same repository and configuration, **When** the user runs create from a regular worktree directory, **Then** the command behavior and output remain consistent with existing behavior.
+
+---
+
+### User Story 2 - Resolve config in bare repo context (Priority: P2)
+
+As a developer, I can run create in a bare repository even when workspace configuration is not physically present in the bare root filesystem view, as long as that configuration exists in the repository's primary branch content.
+
+**Why this priority**: The current failure is caused by config lookup in the wrong context; resolving configuration correctly is required for the command to work reliably.
+
+**Independent Test**: Use a bare repository where configuration exists in branch content, run create from the bare root, and verify config lookup succeeds without a false "config not found" error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bare repository where configuration exists in repository content, **When** the user runs create from the bare root, **Then** configuration is discovered and the command proceeds.
+2. **Given** a bare repository with no workspace configuration, **When** the user runs create, **Then** the command fails with clear guidance on how to initialize configuration.
+
+---
+
+### User Story 3 - Fail safely with actionable guidance (Priority: P3)
+
+As a developer, if create cannot run from a bare repository due to missing prerequisites, I receive a clear error that explains what is missing and what to do next.
+
+**Why this priority**: Clear recovery steps reduce support burden and let users self-correct quickly when setup is incomplete.
+
+**Independent Test**: In a bare repository with intentionally missing prerequisites, run create and verify the command returns a non-success outcome with actionable recovery instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bare repository where required setup is incomplete, **When** the user runs create, **Then** the command reports the exact missing prerequisite and a concrete next step.
+
+### Edge Cases
+
+- Bare repository has multiple candidate branches and no clear primary branch selection.
+- A create request uses a branch/worktree name that already exists.
+- Required repository metadata is inaccessible due to permissions or corruption.
+- Command is interrupted mid-operation and must avoid leaving partial, unusable artifacts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect when create is executed from a bare repository context.
+- **FR-002**: The system MUST resolve workspace configuration for create in bare repository context when configuration exists in repository content.
+- **FR-003**: The system MUST execute create operations in a valid repository context that supports worktree operations, regardless of whether invocation started in a bare root or a regular worktree directory.
+- **FR-004**: The system MUST preserve existing create command behavior for non-bare invocation paths.
+- **FR-005**: The system MUST provide a clear, actionable error when workspace configuration is unavailable, including a concrete next step to resolve it.
+- **FR-006**: The system MUST reject create requests that conflict with existing branch or worktree names and explain the conflict.
+- **FR-007**: The system MUST avoid leaving partially created worktrees or branch state when create fails.
+- **FR-008**: The system MUST present consistent command outcomes for equivalent inputs across supported repository entry points.
+
+### Key Entities *(include if feature involves data)*
+
+- **Repository Context**: The invocation environment for a command (bare root or worktree directory), including repository metadata needed to choose a valid execution path.
+- **Workspace Configuration**: User-managed workspace setup data required to validate repositories and create worktrees.
+- **Create Request**: User input for creating a new worktree/branch, including requested name and command options.
+- **Create Result**: Outcome of a create operation, including success state, created artifacts, or actionable failure details.
+
+## Assumptions
+
+- Users running create from a bare repository intend behavior equivalent to running the same command from a valid worktree.
+- Workspace configuration remains the authoritative source for repository setup requirements.
+- Existing create naming and validation rules remain unchanged unless explicitly required for bare repository compatibility.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of create attempts from bare repositories with valid setup complete without a false "configuration not found" failure.
+- **SC-002**: At least 95% of users can complete a bare-repository create workflow on their first attempt using command output alone.
+- **SC-003**: For invalid setup cases, 100% of failures include a specific corrective action that allows a user to retry successfully.
+- **SC-004**: Support reports for "create from bare repository" failures decrease by at least 80% within one release cycle after launch.

--- a/specs/032-fix-bare-create-command/tasks.md
+++ b/specs/032-fix-bare-create-command/tasks.md
@@ -1,0 +1,206 @@
+---
+
+description: "Task list for fix create command in bare repositories"
+---
+
+# Tasks: Fix create command in bare repositories
+
+**Input**: Design documents from `specs/032-fix-bare-create-command/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Include unit and integration test tasks because this feature is a regression fix and the design requires targeted coverage for bare-repository invocation paths.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare focused test and command scaffolding for bare-context create work.
+
+- [X] T001 Add shared bare-workspace fixture utilities in `repos/arashi/tests/helpers/create-bare-create-workspace.ts`
+- [X] T002 Add create command bare-context test scaffold in `repos/arashi/tests/unit/commands/create.bare-context.test.ts`
+- [X] T003 [P] Add integration harness for bare create flows in `repos/arashi/tests/integration/create.bare-context.setup.test.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build shared context/config resolution primitives used by all user stories.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Add create invocation context types and resolver entry point in `repos/arashi/src/commands/create.ts`
+- [X] T005 [P] Add config source resolution helpers (local-file vs repository-content) in `repos/arashi/src/lib/config.ts`
+- [X] T006 [P] Add git helper to read tracked file content from default branch in `repos/arashi/src/lib/git.ts`
+- [X] T007 Wire create command to use resolved execution context before repository discovery in `repos/arashi/src/commands/create.ts`
+- [X] T008 Add unit coverage for context/config resolver primitives in `repos/arashi/tests/unit/config.bare-context.test.ts`
+
+**Checkpoint**: Context and config resolution are reusable and stable for all story work.
+
+---
+
+## Phase 3: User Story 1 - Run create from bare repo root (Priority: P1) 🎯 MVP
+
+**Goal**: Let users run `create` from a bare repository root and get successful coordinated worktree creation.
+
+**Independent Test**: In a bare repository with valid workspace configuration, run `arashi create <branch>` from bare root and verify worktrees are created and output matches expected success behavior.
+
+### Tests for User Story 1
+
+- [X] T009 [P] [US1] Add integration test for bare-root create success in `repos/arashi/tests/integration/create.bare-root-success.test.ts`
+- [X] T010 [P] [US1] Add integration test for non-bare behavior parity in `repos/arashi/tests/integration/create.non-bare-parity.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Update create repository discovery to run from resolved execution path in `repos/arashi/src/commands/create.ts`
+- [X] T012 [US1] Update meta-repo inclusion logic to use resolved execution path in `repos/arashi/src/commands/create.ts`
+- [X] T013 [US1] Ensure create orchestration receives normalized repository paths across bare/non-bare entry points in `repos/arashi/src/commands/create.ts`
+
+**Checkpoint**: User Story 1 is functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Resolve config in bare repo context (Priority: P2)
+
+**Goal**: Resolve workspace configuration correctly in bare repositories, including repository-content fallback when local file lookup is unavailable.
+
+**Independent Test**: In a bare repository where config exists in repository content but not in bare-root filesystem view, run `create` and verify command proceeds without false config-not-found failure.
+
+### Tests for User Story 2
+
+- [X] T014 [P] [US2] Add unit tests for repository-content config fallback loading in `repos/arashi/tests/unit/config.bare-context.test.ts`
+- [X] T015 [P] [US2] Add integration test for bare-root config fallback success in `repos/arashi/tests/integration/create.bare-config-fallback.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Implement repository-content config fallback loader in `repos/arashi/src/lib/config.ts`
+- [X] T017 [US2] Call fallback loader when local config resolution fails in create path in `repos/arashi/src/commands/create.ts`
+- [X] T018 [US2] Validate fallback-loaded config with existing validation flow in `repos/arashi/src/lib/config.ts`
+
+**Checkpoint**: User Story 2 is functional and independently testable.
+
+---
+
+## Phase 5: User Story 3 - Fail safely with actionable guidance (Priority: P3)
+
+**Goal**: Provide actionable failure messages for missing prerequisites and preserve safe rollback behavior for failed bare-root creates.
+
+**Independent Test**: In a bare repository with missing setup, run `create` and verify error output provides concrete next steps; in failure scenarios, verify no partial artifacts remain.
+
+### Tests for User Story 3
+
+- [X] T019 [P] [US3] Add integration test for missing-config guidance error in `repos/arashi/tests/integration/create.bare-missing-config-error.test.ts`
+- [X] T020 [P] [US3] Add integration test for bare-root conflict reporting in `repos/arashi/tests/integration/create.bare-conflict-error.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T021 [US3] Improve create error mapping for bare-context setup failures in `repos/arashi/src/commands/create.ts`
+- [X] T022 [US3] Ensure failed bare-context create preserves rollback guarantees in `repos/arashi/src/core/worktree.ts`
+- [X] T023 [US3] Standardize actionable conflict and setup guidance text in `repos/arashi/src/commands/create.ts`
+
+**Checkpoint**: User Story 3 is functional and independently testable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize docs and spec artifacts spanning multiple stories.
+
+- [X] T024 [P] Update bare-repository create usage notes in `repos/arashi/README.md`
+- [X] T025 [P] Align quickstart validation steps with final behavior in `specs/032-fix-bare-create-command/quickstart.md`
+- [X] T026 [P] Align contract examples and error semantics with implemented behavior in `specs/032-fix-bare-create-command/contracts/create-bare-context.openapi.yaml`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; starts immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks all story implementation.
+- **User Story Phases (Phase 3-5)**: Depend on Phase 2 completion.
+- **Polish (Phase 6)**: Depends on completion of desired user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational; no dependency on US2 or US3.
+- **US2 (P2)**: Starts after Foundational; independent, but can reuse US1 context plumbing.
+- **US3 (P3)**: Starts after Foundational; independent, but validates failures from US1/US2 paths.
+
+### Dependency Graph
+
+- Phase 1 -> Phase 2 -> US1 (MVP)
+- Phase 2 -> US2
+- Phase 2 -> US3
+- US1 + US2 + US3 -> Phase 6
+
+### Parallel Opportunities
+
+- **Setup**: T003 can run in parallel with T001-T002 after initial fixture direction is set.
+- **Foundational**: T005 and T006 can run in parallel (different files).
+- **US1**: T009 and T010 can run in parallel; T011-T013 remain sequential in `create.ts`.
+- **US2**: T014 and T015 can run in parallel; T016 and T018 can split across `config.ts` while T017 updates `create.ts`.
+- **US3**: T019 and T020 can run in parallel; T021 and T022 can run in parallel across command/core modules before T023 finalizes user messaging.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Run independent US1 test tasks together
+Task: "Add integration test for bare-root create success in repos/arashi/tests/integration/create.bare-root-success.test.ts"
+Task: "Add integration test for non-bare behavior parity in repos/arashi/tests/integration/create.non-bare-parity.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Split US2 work between unit and integration coverage
+Task: "Add unit tests for repository-content config fallback loading in repos/arashi/tests/unit/config.bare-context.test.ts"
+Task: "Add integration test for bare-root config fallback success in repos/arashi/tests/integration/create.bare-config-fallback.test.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Validate independent failure paths in parallel
+Task: "Add integration test for missing-config guidance error in repos/arashi/tests/integration/create.bare-missing-config-error.test.ts"
+Task: "Add integration test for bare-root conflict reporting in repos/arashi/tests/integration/create.bare-conflict-error.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup).
+2. Complete Phase 2 (Foundational).
+3. Complete Phase 3 (US1).
+4. Validate US1 independently using the story independent test criteria.
+
+### Incremental Delivery
+
+1. Deliver US1 (bare-root create success) as MVP.
+2. Deliver US2 (config resolution fallback) and validate independently.
+3. Deliver US3 (actionable failure guidance and safe failure handling).
+4. Complete Phase 6 polish updates.
+
+### Independent Test Criteria by Story
+
+- **US1**: Bare-root create succeeds and produces expected worktree outputs with parity to non-bare invocation.
+- **US2**: Bare-root create resolves config from repository content when local file path is unavailable.
+- **US3**: Missing setup and conflict cases return actionable guidance and leave no partial artifacts.
+
+---
+
+## Notes
+
+- Tasks are ordered for execution readiness and independent delivery.
+- All task lines follow the required checklist format with IDs, optional `[P]`, required `[USx]` on story tasks, and explicit file paths.
+- Contract mapping used: `/create/execute` -> US1, `/create/validate-context` -> US2, error response semantics -> US3.


### PR DESCRIPTION
## Summary
- add complete spec artifacts for `032-fix-bare-create-command` including plan, research, data model, contracts, quickstart, and tasks
- update checklist/task tracking with completed implementation status and validation expectations
- record the new feature entry in `AGENTS.md` technology and recent-changes sections

## Linkage
- Related to corwinm/arashi-arashi#57
- Implemented by https://github.com/corwinm/arashi/pull/26