### PR TITLE
specs: add docs-domain migration artifacts for issue #86

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ config-mgmt/
 - File system (skill metadata, docs, scripts, and examples) (033-skills-sh-integration)
 - Filesystem documentation content and static site artifacts (no application database) (034-init-docs-site)
 - Markdown (CommonMark) for content, TypeScript-based static site toolchain for build/runtime orchestration + Astro, Starlight, Netlify for hosting/deploy previews, GitHub Actions for validation and link health checks (034-init-docs-site)
+- Markdown (CommonMark), TypeScript 5.9, JavaScript module config, YAML workflow definitions + Bun runtime scripts, Astro/Starlight site configuration, GitHub Actions workflows, Netlify publication pipeline (035-update-docs-domain)
+- Filesystem content and repository metadata only (no application database) (035-update-docs-domain)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -104,10 +106,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 035-update-docs-domain: Added Markdown (CommonMark), TypeScript 5.9, JavaScript module config, YAML workflow definitions + Bun runtime scripts, Astro/Starlight site configuration, GitHub Actions workflows, Netlify publication pipeline
 - 034-init-docs-site: Added Markdown (CommonMark) for content, TypeScript-based static site toolchain for build/runtime orchestration + Astro, Starlight, Netlify for hosting/deploy previews, GitHub Actions for validation and link health checks
 - 033-skills-sh-integration: Added Markdown (CommonMark), YAML 1.2, shell scripts (POSIX/Bash compatible) + skills CLI/skills.sh conventions, GitHub repository hosting, Arashi CLI distribution artifacts
-- 032-fix-bare-create-command: Added TypeScript 5.9 + Bun runtime, commander, chalk, ora, @inquirer/prompts
-- 031-audit-readmes: Added Markdown (CommonMark), YAML for workflow badge targets, JSON for package metadata validation + Existing repository metadata in `repos/arashi` (`package.json`, GitHub workflows, LICENSE), Markdown link conventions, badge providers (GitHub Actions and npm badge endpoints)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/035-update-docs-domain/checklists/requirements.md
+++ b/specs/035-update-docs-domain/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Update Docs Domain Across Projects
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-02-10  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1 completed; all checklist items pass.

--- a/specs/035-update-docs-domain/contracts/docs-domain-migration.openapi.yaml
+++ b/specs/035-update-docs-domain/contracts/docs-domain-migration.openapi.yaml
@@ -1,0 +1,416 @@
+openapi: 3.1.0
+info:
+  title: Documentation Domain Migration Contract
+  version: 1.0.0
+  description: |
+    Planning contract for defining a canonical documentation domain,
+    auditing and replacing deprecated-domain references, handling
+    approved exceptions, and publishing migration evidence.
+servers:
+  - url: https://docs-governance.local
+
+paths:
+  /canonical-domain:
+    put:
+      summary: Set the active canonical documentation domain
+      operationId: setCanonicalDomain
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CanonicalDomainRequest'
+      responses:
+        '200':
+          description: Canonical domain updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CanonicalDomain'
+
+  /migration-scopes:
+    post:
+      summary: Define migration scope surfaces
+      operationId: createMigrationScope
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MigrationScopeRequest'
+      responses:
+        '201':
+          description: Migration scope created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationScope'
+
+  /migration-scopes/{scopeId}/references:audit:
+    post:
+      summary: Audit documentation references in scope
+      operationId: auditReferences
+      parameters:
+        - $ref: '#/components/parameters/ScopeId'
+      responses:
+        '200':
+          description: Reference audit completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReferenceAuditResult'
+
+  /migration-scopes/{scopeId}/references:replace:
+    post:
+      summary: Replace deprecated-domain references with canonical domain
+      operationId: replaceReferences
+      parameters:
+        - $ref: '#/components/parameters/ScopeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReplaceReferencesRequest'
+      responses:
+        '202':
+          description: Replacement operation accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplacementRun'
+
+  /migration-scopes/{scopeId}/exceptions:
+    post:
+      summary: Register an approved migration exception
+      operationId: registerException
+      parameters:
+        - $ref: '#/components/parameters/ScopeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExceptionRequest'
+      responses:
+        '201':
+          description: Exception registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationException'
+
+  /migration-scopes/{scopeId}/verification:
+    post:
+      summary: Verify migration outcomes and link health
+      operationId: verifyMigration
+      parameters:
+        - $ref: '#/components/parameters/ScopeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerificationRequest'
+      responses:
+        '200':
+          description: Verification completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerificationResult'
+
+  /migration-scopes/{scopeId}/evidence:
+    post:
+      summary: Generate release approval evidence
+      operationId: generateEvidence
+      parameters:
+        - $ref: '#/components/parameters/ScopeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvidenceRequest'
+      responses:
+        '201':
+          description: Evidence generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationEvidence'
+
+components:
+  parameters:
+    ScopeId:
+      name: scopeId
+      in: path
+      required: true
+      schema:
+        type: string
+
+  schemas:
+    CanonicalDomainRequest:
+      type: object
+      required: [baseUrl, effectiveDate, approvedBy]
+      properties:
+        baseUrl:
+          type: string
+          format: uri
+          example: https://arashi.haphazard.dev
+        effectiveDate:
+          type: string
+          format: date
+        approvedBy:
+          type: string
+
+    CanonicalDomain:
+      type: object
+      required: [domainId, baseUrl, status, effectiveDate, approvedBy]
+      properties:
+        domainId:
+          type: string
+        baseUrl:
+          type: string
+          format: uri
+        status:
+          type: string
+          enum: [proposed, approved, active]
+        effectiveDate:
+          type: string
+          format: date
+        approvedBy:
+          type: string
+
+    MigrationScopeRequest:
+      type: object
+      required: [name, surfaces]
+      properties:
+        name:
+          type: string
+        surfaces:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ProjectSurface'
+
+    MigrationScope:
+      type: object
+      required: [scopeId, name, surfaceCount]
+      properties:
+        scopeId:
+          type: string
+        name:
+          type: string
+        surfaceCount:
+          type: integer
+
+    ProjectSurface:
+      type: object
+      required: [surfaceId, repository, path, surfaceType, owner, inScope]
+      properties:
+        surfaceId:
+          type: string
+        repository:
+          type: string
+          example: repos/arashi-docs
+        path:
+          type: string
+          example: repos/arashi-docs/README.md
+        surfaceType:
+          type: string
+          enum: [readme, site-config, contributor-doc, validation-script, workflow]
+        owner:
+          type: string
+        inScope:
+          type: boolean
+
+    ReferenceAuditResult:
+      type: object
+      required: [scopeId, auditedAt, totalReferences, targetDomainReferences, nonTargetReferences]
+      properties:
+        scopeId:
+          type: string
+        auditedAt:
+          type: string
+          format: date-time
+        totalReferences:
+          type: integer
+        targetDomainReferences:
+          type: integer
+        nonTargetReferences:
+          type: integer
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentationReference'
+
+    DocumentationReference:
+      type: object
+      required:
+        [referenceId, surfaceId, currentUrl, normalizedUrl, classification, migrationStatus]
+      properties:
+        referenceId:
+          type: string
+        surfaceId:
+          type: string
+        currentUrl:
+          type: string
+          format: uri
+        normalizedUrl:
+          type: string
+          format: uri
+        classification:
+          type: string
+          enum: [target-domain, non-target, candidate-exception]
+        migrationStatus:
+          type: string
+          enum: [detected, updated, validated, excepted]
+        pathQueryFragmentPreserved:
+          type: boolean
+
+    ReplaceReferencesRequest:
+      type: object
+      required: [canonicalBaseUrl, preservePathQueryFragment]
+      properties:
+        canonicalBaseUrl:
+          type: string
+          format: uri
+          example: https://arashi.haphazard.dev
+        preservePathQueryFragment:
+          type: boolean
+          default: true
+        includeReferenceIds:
+          type: array
+          items:
+            type: string
+
+    ReplacementRun:
+      type: object
+      required: [runId, scopeId, status, updatedReferences, startedAt]
+      properties:
+        runId:
+          type: string
+        scopeId:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, completed, failed]
+        updatedReferences:
+          type: integer
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+
+    ExceptionRequest:
+      type: object
+      required: [referenceId, reason, owner]
+      properties:
+        referenceId:
+          type: string
+        reason:
+          type: string
+        owner:
+          type: string
+
+    MigrationException:
+      type: object
+      required: [exceptionId, referenceId, reason, owner, approvedAt, status]
+      properties:
+        exceptionId:
+          type: string
+        referenceId:
+          type: string
+        reason:
+          type: string
+        owner:
+          type: string
+        approvedAt:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [proposed, approved, rejected]
+
+    VerificationRequest:
+      type: object
+      required: [checkNames]
+      properties:
+        checkNames:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            enum:
+              [
+                canonical-domain-consistency,
+                readme-entrypoint-health,
+                internal-link-health,
+                exception-completeness,
+              ]
+
+    VerificationResult:
+      type: object
+      required: [scopeId, checkedAt, outcome, criticalBrokenLinks]
+      properties:
+        scopeId:
+          type: string
+        checkedAt:
+          type: string
+          format: date-time
+        outcome:
+          type: string
+          enum: [pass, fail]
+        criticalBrokenLinks:
+          type: integer
+        findings:
+          type: array
+          items:
+            type: string
+
+    EvidenceRequest:
+      type: object
+      required: [generatedBy]
+      properties:
+        generatedBy:
+          type: string
+        approver:
+          type: string
+
+    MigrationEvidence:
+      type: object
+      required:
+        [
+          evidenceId,
+          scopeId,
+          generatedAt,
+          generatedBy,
+          totalTargetReferences,
+          updatedReferences,
+          approvedExceptions,
+          validationOutcome,
+        ]
+      properties:
+        evidenceId:
+          type: string
+        scopeId:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        generatedBy:
+          type: string
+        approver:
+          type: string
+        totalTargetReferences:
+          type: integer
+        updatedReferences:
+          type: integer
+        approvedExceptions:
+          type: integer
+        validationOutcome:
+          type: string
+          enum: [pass, fail]

--- a/specs/035-update-docs-domain/data-model.md
+++ b/specs/035-update-docs-domain/data-model.md
@@ -1,0 +1,136 @@
+# Data Model: Update Docs Domain Across Projects
+
+**Feature**: 035-update-docs-domain  
+**Date**: 2026-02-10
+
+## Overview
+
+This feature defines planning-level entities for replacing deprecated documentation-domain references with a canonical domain across multiple project surfaces, while preserving URL semantics and maintaining auditable exception handling.
+
+## Entities
+
+### 1. Canonical Documentation Domain
+
+**Description**: The single approved base domain for user-facing project documentation links.
+
+**Fields**:
+
+- `domain_id` (string, required)
+- `base_url` (string, required)
+- `status` (enum, required): `proposed` | `approved` | `active`
+- `effective_date` (date, required)
+- `approved_by` (string, required)
+
+**Validation Rules**:
+
+- `base_url` MUST use HTTPS.
+- Only one record can be `active` at a time.
+- All in-scope documentation references MUST resolve under the active `base_url` unless explicitly excepted.
+
+### 2. Project Surface
+
+**Description**: A user-facing artifact that can contain documentation references.
+
+**Fields**:
+
+- `surface_id` (string, required)
+- `repository` (string, required)
+- `path` (string, required)
+- `surface_type` (enum, required): `readme` | `site-config` | `contributor-doc` | `validation-script` | `workflow`
+- `in_scope` (boolean, required)
+- `owner` (string, required)
+
+**Validation Rules**:
+
+- Every `in_scope=true` surface MUST be represented in migration evidence.
+- Each surface MUST have one accountable owner.
+- Surface path MUST be unique within the migration scope.
+
+### 3. Documentation Reference
+
+**Description**: A concrete URL occurrence within a project surface.
+
+**Fields**:
+
+- `reference_id` (string, required)
+- `surface_id` (string, required)
+- `current_url` (string, required)
+- `normalized_url` (string, required)
+- `classification` (enum, required): `target-domain` | `non-target` | `candidate-exception`
+- `migration_status` (enum, required): `detected` | `updated` | `validated` | `excepted`
+- `path_query_fragment_preserved` (boolean, required)
+
+**Validation Rules**:
+
+- `classification=target-domain` references MUST end in `updated` or `excepted`.
+- Domain-only replacements MUST keep path/query/fragment intact when `migration_status=updated`.
+- `classification=non-target` references MUST remain unchanged.
+
+### 4. Migration Exception
+
+**Description**: A justified, approved case where a target-domain reference is not replaced.
+
+**Fields**:
+
+- `exception_id` (string, required)
+- `reference_id` (string, required)
+- `reason` (string, required)
+- `owner` (string, required)
+- `approved_at` (date-time, required)
+- `status` (enum, required): `proposed` | `approved` | `rejected`
+
+**Validation Rules**:
+
+- Every exception MUST include a clear reason and accountable owner.
+- Only `approved` exceptions can satisfy closure for unreplaced target references.
+- Rejected exceptions MUST return the related reference to `detected` status.
+
+### 5. Migration Evidence Record
+
+**Description**: Release-facing proof that migration scope was completed and verified.
+
+**Fields**:
+
+- `evidence_id` (string, required)
+- `generated_at` (date-time, required)
+- `generated_by` (string, required)
+- `total_target_references` (integer, required)
+- `updated_references` (integer, required)
+- `approved_exceptions` (integer, required)
+- `validation_outcome` (enum, required): `pass` | `fail`
+- `approver` (string, optional)
+
+**Validation Rules**:
+
+- `updated_references + approved_exceptions` MUST equal `total_target_references` for a passing release gate.
+- `validation_outcome=pass` requires zero critical broken-link findings.
+- Evidence MUST be available for release approval review.
+
+## Relationships
+
+- One `Canonical Documentation Domain` applies to many `Project Surface` records.
+- One `Project Surface` contains many `Documentation Reference` records.
+- One `Documentation Reference` can have zero or one `Migration Exception`.
+- One `Migration Evidence Record` summarizes many `Documentation Reference` updates and `Migration Exception` decisions.
+
+## State Transitions
+
+### Canonical Documentation Domain
+
+`proposed -> approved -> active`
+
+### Documentation Reference
+
+`detected -> updated -> validated`
+
+or
+
+`detected -> excepted` (with approved exception)
+
+### Migration Exception
+
+`proposed -> approved`
+
+or
+
+`proposed -> rejected`

--- a/specs/035-update-docs-domain/plan.md
+++ b/specs/035-update-docs-domain/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Update Docs Domain Across Projects
+
+**Branch**: `035-update-docs-domain` | **Date**: 2026-02-10 | **Spec**: `specs/035-update-docs-domain/spec.md`
+**Input**: Feature specification from `specs/035-update-docs-domain/spec.md`
+
+## Summary
+
+Replace deprecated default Netlify documentation-domain references with `https://arashi.haphazard.dev` across in-scope project surfaces, preserve URL path/query/fragment semantics, and provide auditable migration evidence plus policy checks that prevent reintroducing deprecated domain references.
+
+## Technical Context
+
+**Language/Version**: Markdown (CommonMark), TypeScript 5.9, JavaScript module config, YAML workflow definitions  
+**Primary Dependencies**: Bun runtime scripts, Astro/Starlight site configuration, GitHub Actions workflows, Netlify publication pipeline  
+**Storage**: Filesystem content and repository metadata only (no application database)  
+**Testing**: `bun run validate` quality gates in `repos/arashi-docs`, README link health checks, repository CI checks for changed surfaces  
+**Target Platform**: Multi-repository documentation surfaces in `repos/arashi` and `repos/arashi-docs`, with public docs endpoint at `https://arashi.haphazard.dev`  
+**Project Type**: Multi-repository documentation/configuration migration  
+**Performance Goals**: Full migration verification evidence can be reviewed by an approver within 30 minutes; no critical broken-link findings at acceptance  
+**Constraints**: Preserve path/query/fragment when replacing domain-only URL components; do not alter non-target external links; document immutable/external exceptions with owner and reason  
+**Scale/Scope**: Current in-scope baseline is 5 identified deprecated-domain references across 2 repositories, plus policy/validation updates to prevent regressions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Single-file executable distribution: unchanged (docs-domain update only) - Pass
+- II. Automatic worktree management: unchanged - Pass
+- III. Error recovery and rollback behavior: unchanged - Pass
+- IV. User-centric interface: improved by reducing stale documentation entry points - Pass
+- V. Minimalist configuration: preserved by centralizing one canonical docs domain - Pass
+- VI. Cross-platform compatibility: preserved (content/config updates only) - Pass
+- VII. Test coverage and automated quality checks: supported via existing docs validation gates and added policy verification scope - Pass
+- VIII. Semantic versioning: unchanged for product release behavior - Pass
+- IX. Hook system: unaffected - Pass
+- X. Performance standards: unaffected for CLI runtime; migration verification kept lightweight and auditable - Pass
+
+**Gate Result (Pre-Research)**: Pass.
+
+**Post-Design Re-check**: Pass (research, data model, contracts, and quickstart keep constitutional principles intact; no exceptions required).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/035-update-docs-domain/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── docs-domain-migration.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+└── README.md
+
+repos/arashi-docs/
+├── README.md
+├── astro.config.mjs
+├── scripts/
+│   └── check-readme-link.ts
+├── docs/
+│   └── contributing/
+│       └── validation-troubleshooting.md
+└── .github/
+    └── workflows/
+        └── docs-validate.yml
+```
+
+**Structure Decision**: Keep planning artifacts in `specs/035-update-docs-domain` and implement migration/policy enforcement in existing documentation surfaces under `repos/arashi` and `repos/arashi-docs`, where current canonical URL coupling already exists.
+
+## Complexity Tracking
+
+No constitutional violations identified; no complexity exceptions required.

--- a/specs/035-update-docs-domain/quickstart.md
+++ b/specs/035-update-docs-domain/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: Update Docs Domain Across Projects
+
+**Feature**: 035-update-docs-domain  
+**Audience**: Maintainers updating canonical documentation links across repositories  
+**Last Updated**: 2026-02-10
+
+## Goal
+
+Migrate all in-scope deprecated documentation-domain references to `https://arashi.haphazard.dev`, preserve deep-link semantics, and produce release-ready verification evidence.
+
+## Prerequisites
+
+- Workspace includes synchronized repositories under `repos/`.
+- You can edit and validate these in-scope surfaces:
+  - `repos/arashi/README.md`
+  - `repos/arashi-docs/README.md`
+  - `repos/arashi-docs/astro.config.mjs`
+  - `repos/arashi-docs/scripts/check-readme-link.ts`
+  - `repos/arashi-docs/docs/contributing/validation-troubleshooting.md`
+- You can run docs validation checks in `repos/arashi-docs`.
+
+## Step 1: Confirm Canonical Domain Policy
+
+1. Confirm the approved canonical docs domain is `https://arashi.haphazard.dev`.
+2. Confirm all in-scope projects/surfaces for this migration window.
+3. Define any known immutable or external artifacts that may require exception handling.
+
+## Step 2: Audit Current References
+
+1. Inventory target-domain references in all in-scope surfaces.
+2. Classify each finding as:
+   - target-domain reference to replace,
+   - non-target reference to keep,
+   - candidate exception.
+3. Record baseline counts for release evidence.
+
+## Step 3: Apply Domain Updates
+
+1. Replace deprecated docs-domain references with `https://arashi.haphazard.dev`.
+2. Preserve existing path/query/fragment components for domain-only replacements.
+3. Leave non-target external URLs unchanged.
+
+## Step 4: Handle Exceptions Explicitly
+
+1. For each unreplaced target reference, create an exception record.
+2. Include impacted surface, reason, and accountable owner.
+3. Ensure exception approvals are captured before release approval.
+
+## Step 5: Validate Canonical Consistency
+
+1. Run docs quality gates and README-link health checks in `repos/arashi-docs`.
+2. Verify primary documentation entry points in scope resolve to the canonical domain on first click.
+3. Confirm no critical broken-link findings remain.
+
+## Step 6: Produce Migration Evidence
+
+1. Publish an evidence record listing:
+   - all updated target references,
+   - all approved exceptions,
+   - validation results.
+2. Confirm that `updated + approved exceptions = total target references`.
+3. Share evidence with release approver for final sign-off.
+
+## Expected Outcome
+
+All in-scope documentation entry points consistently use `https://arashi.haphazard.dev`, deprecated-domain references are removed or explicitly excepted, and release approval can be completed quickly from a single audit trail.

--- a/specs/035-update-docs-domain/research.md
+++ b/specs/035-update-docs-domain/research.md
@@ -1,0 +1,89 @@
+# Research: Update Docs Domain Across Projects
+
+**Date**: 2026-02-10  
+**Feature**: 035-update-docs-domain  
+**Purpose**: Resolve planning unknowns around migration scope, canonical URL policy, and regression prevention.
+
+## 1) In-Scope Surface Inventory
+
+### Decision
+
+Treat the following five references as the initial migration scope:
+
+- `repos/arashi/README.md`
+- `repos/arashi-docs/README.md`
+- `repos/arashi-docs/astro.config.mjs`
+- `repos/arashi-docs/scripts/check-readme-link.ts`
+- `repos/arashi-docs/docs/contributing/validation-troubleshooting.md`
+
+### Rationale
+
+- These are active, user-facing or policy-driving references to the deprecated default docs domain.
+- They include the two coupled entry points (`repos/arashi/README.md` and the docs-repo URL health check) that must remain aligned.
+- They cover canonical site config, maintainer guidance, and top-level discoverability.
+
+### Alternatives considered
+
+- Broaden scope to every `netlify` string in the workspace: rejected because many are non-URL artifacts (for example `.netlify/` ignore entries and dependency names).
+- Limit scope to README links only: rejected because canonical site config and validation fallback would still drift.
+
+## 2) Canonical URL Policy and Replacement Semantics
+
+### Decision
+
+Adopt `https://arashi.haphazard.dev` as the single canonical documentation domain and apply domain-only replacements that preserve existing path, query, and fragment values.
+
+### Rationale
+
+- A single HTTPS host avoids canonical ambiguity and inconsistent user paths.
+- Domain-only replacement minimizes user-facing breakage and preserves deep links.
+- Preserving URL suffix components aligns with FR-004 and reduces migration risk.
+
+### Alternatives considered
+
+- Allow multiple canonical hosts during steady state: rejected because it weakens consistency and invites regressions.
+- Rewrite paths during domain migration: rejected because it compounds risk and expands scope beyond the requested change.
+
+## 3) Deprecated-Domain Exception Policy
+
+### Decision
+
+Exclude non-URL and generated/vendor artifacts from replacement scope and treat them as documented exceptions when they contain non-target `netlify` text.
+
+### Rationale
+
+- Lockfiles, ignore patterns, and workflow path triggers can contain `netlify` tokens unrelated to docs-domain URLs.
+- Explicit exception records preserve auditability while preventing noisy or incorrect edits.
+
+### Alternatives considered
+
+- Replace all `netlify` tokens unconditionally: rejected due to false-positive risk and unnecessary churn.
+- Leave exceptions undocumented: rejected because FR-007 and FR-008 require explicit exception evidence.
+
+## 4) Regression Prevention and Verification Pattern
+
+### Decision
+
+Use canonical URL validation as a release gate by aligning site config, README entry points, and link-health checks, and require migration evidence listing updates plus exceptions.
+
+### Rationale
+
+- Existing `validate:readme-link` behavior already enforces cross-repository canonical URL coupling and can be used as migration guardrail.
+- Evidence-first verification gives approvers a deterministic way to confirm completeness and scope boundaries.
+- Gate-based validation catches regressions before publish or release approval.
+
+### Alternatives considered
+
+- Manual spot checks only: rejected as insufficient for repeatable release approval.
+- Rely on non-blocking external link checks: rejected because availability checks do not enforce canonical-host policy.
+
+## Result
+
+All initial planning unknowns are resolved:
+
+- In-scope deprecated-domain references are identified.
+- Canonical URL and replacement semantics are defined.
+- Exception handling criteria are defined.
+- Verification and regression-prevention approach is defined.
+
+No unresolved `NEEDS CLARIFICATION` items remain.

--- a/specs/035-update-docs-domain/spec.md
+++ b/specs/035-update-docs-domain/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Update Docs Domain Across Projects
+
+**Feature Branch**: `035-update-docs-domain`  
+**Created**: 2026-02-10  
+**Status**: Draft  
+**Input**: User description: "https://github.com/corwinm/arashi-arashi/issues/86 - Update docs domain across projects. Replace the default netlify domain with https://arashi.haphazard.dev"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Standardize Project Documentation Links (Priority: P1)
+
+As a project maintainer, I need every in-scope project to use one canonical documentation domain so users consistently land on the correct docs site.
+
+**Why this priority**: This is the core business outcome: eliminating split or outdated documentation destinations across projects.
+
+**Independent Test**: Audit each in-scope project surface for documentation URLs and confirm all deprecated default domain references are replaced by the canonical domain.
+
+**Acceptance Scenarios**:
+
+1. **Given** an in-scope project surface contains a URL with the deprecated default docs domain, **When** the domain update is applied, **Then** that URL uses `https://arashi.haphazard.dev`.
+2. **Given** a deprecated-domain URL includes a path, query, or fragment, **When** it is updated, **Then** the same destination path/query/fragment remains intact under the canonical domain.
+
+---
+
+### User Story 2 - Keep Future Links Consistent (Priority: P2)
+
+As a contributor, I need clear expectations for documentation URLs so new or edited project links continue using the canonical docs domain.
+
+**Why this priority**: Preventing regressions keeps the migration durable and avoids reintroducing user confusion.
+
+**Independent Test**: Add or edit representative documentation links in scope and verify review criteria require canonical-domain usage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor adds a new documentation link in an in-scope project surface, **When** the change is reviewed against the feature requirements, **Then** the link uses the canonical docs domain.
+2. **Given** a contributor updates an existing docs link, **When** the update is completed, **Then** no deprecated default docs domain reference is introduced.
+
+---
+
+### User Story 3 - Approve Migration with Evidence (Priority: P3)
+
+As a release approver, I need a clear migration record so I can confirm scope coverage and approve the update confidently.
+
+**Why this priority**: Verification evidence reduces release risk and makes scope boundaries explicit.
+
+**Independent Test**: Review the migration evidence and confirm it lists all updated references and any approved exceptions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the migration is complete, **When** the approver reviews the audit record, **Then** it includes all updated in-scope references.
+2. **Given** any deprecated-domain reference cannot be updated, **When** the migration is reviewed, **Then** each exception includes an explicit reason and owner.
+
+### Edge Cases
+
+- A deprecated-domain link appears in multiple formats (plain text URL, markdown link, badge target) within the same project surface.
+- A URL contains nested paths or anchors that must remain unchanged after domain replacement.
+- A non-target external URL looks similar to the deprecated domain and must not be modified.
+- A historical or immutable artifact cannot be edited and must be tracked as an approved exception.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The feature MUST define `https://arashi.haphazard.dev` as the canonical documentation domain for all in-scope projects.
+- **FR-002**: The feature MUST define and publish the in-scope project surfaces that are subject to domain replacement.
+- **FR-003**: The feature MUST replace every in-scope reference to the deprecated default docs domain with the canonical documentation domain.
+- **FR-004**: When replacing domain-only URL components, the feature MUST preserve existing path, query, and fragment content unless an explicit exception is documented.
+- **FR-005**: Each in-scope project MUST provide at least one primary documentation entry point that resolves to the canonical domain.
+- **FR-006**: The feature MUST leave non-target external links unchanged.
+- **FR-007**: The feature MUST produce migration evidence listing all updated references and all approved exceptions.
+- **FR-008**: Any approved exception MUST include the impacted surface, reason for exception, and accountable owner.
+
+### Key Entities *(include if feature involves data)*
+
+- **Canonical Documentation Domain**: The official base URL used for project documentation access.
+- **Documentation Reference**: Any user-visible URL that points to project documentation.
+- **Project Surface**: A user-facing project artifact that can contain documentation references.
+- **Migration Exception**: An approved, documented case where a deprecated-domain reference remains unchanged.
+
+### Assumptions
+
+- In-scope projects are all actively maintained Arashi repositories and documentation surfaces managed in this workspace.
+- The deprecated domain is the previous default Netlify-hosted documentation domain currently referenced by in-scope materials.
+- Some immutable or externally controlled artifacts may not be editable and can be handled through approved exceptions.
+- This feature changes documentation domains only; it does not redefine documentation content structure.
+
+### Dependencies
+
+- Access to all in-scope project surfaces is available during the migration window.
+- Stakeholders confirm `https://arashi.haphazard.dev` remains the intended long-term canonical documentation domain.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of in-scope deprecated-domain references are either updated to the canonical domain or documented as approved exceptions before release.
+- **SC-002**: 100% of primary documentation entry points across in-scope projects open under the canonical domain on first click.
+- **SC-003**: 0 critical broken-link findings are discovered during acceptance validation of updated documentation references.
+- **SC-004**: A release approver can complete migration verification (including exceptions) in 30 minutes or less using the provided evidence.

--- a/specs/035-update-docs-domain/tasks.md
+++ b/specs/035-update-docs-domain/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Update Docs Domain Across Projects
+
+**Input**: Design documents from `/specs/035-update-docs-domain/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Automated test creation was not explicitly requested in the specification; validation tasks use existing repository quality gates.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Every task includes an exact file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish migration artifacts and shared canonical-domain scaffolding.
+
+- [X] T001 Create in-scope surface manifest in `repos/arashi-docs/docs/contributing/docs-domain-migration-scope.md`
+- [X] T002 Create migration evidence template in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T003 [P] Create approved-exceptions register template in `repos/arashi-docs/docs/contributing/docs-domain-exceptions.md`
+- [X] T004 [P] Create canonical docs URL constant module in `repos/arashi-docs/scripts/lib/canonical-docs-url.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement shared validation and baseline inventory required by all user stories.
+
+**⚠️ CRITICAL**: No user story work begins until this phase is complete.
+
+- [X] T005 Implement canonical-domain policy scanner for in-scope files in `repos/arashi-docs/scripts/check-canonical-docs-domain.ts`
+- [X] T006 Update canonical README-link checker to consume shared URL constant in `repos/arashi-docs/scripts/check-readme-link.ts`
+- [X] T007 Wire `validate:docs-domain` and include it in `validate` pipeline in `repos/arashi-docs/package.json`
+- [X] T008 Update docs validation workflow to run canonical-domain check and include README trigger in `repos/arashi-docs/.github/workflows/docs-validate.yml`
+- [X] T009 Capture baseline deprecated-domain inventory counts in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+
+**Checkpoint**: Shared policy enforcement and baseline inventory are ready.
+
+---
+
+## Phase 3: User Story 1 - Standardize Project Documentation Links (Priority: P1) 🎯 MVP
+
+**Goal**: Replace all in-scope deprecated-domain references with the canonical domain while preserving URL suffix semantics.
+
+**Independent Test**: Audit each in-scope project surface for documentation URLs and confirm all deprecated default domain references are replaced by the canonical domain.
+
+### Implementation for User Story 1
+
+- [X] T010 [P] [US1] Replace the top-level Documentation URL in `repos/arashi/README.md`
+- [X] T011 [P] [US1] Replace canonical docs URL text in `repos/arashi-docs/README.md`
+- [X] T012 [P] [US1] Replace the site base URL with the canonical domain in `repos/arashi-docs/astro.config.mjs`
+- [X] T013 [P] [US1] Replace deprecated-domain troubleshooting guidance in `repos/arashi-docs/docs/contributing/validation-troubleshooting.md`
+- [X] T014 [US1] Set canonical fallback URL to `https://arashi.haphazard.dev` in `repos/arashi-docs/scripts/check-readme-link.ts`
+- [X] T015 [US1] Record before/after URL mapping and path-query-fragment preservation notes in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T016 [US1] Run docs validation gates defined in `repos/arashi-docs/package.json` and log outcomes in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+
+**Checkpoint**: User Story 1 delivers canonical-domain consistency across all current in-scope references.
+
+---
+
+## Phase 4: User Story 2 - Keep Future Links Consistent (Priority: P2)
+
+**Goal**: Prevent future introduction of deprecated-domain references through policy checks and contributor guidance.
+
+**Independent Test**: Add or edit representative documentation links in scope and verify review criteria require canonical-domain usage.
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] Add deprecated-domain denylist and canonical-host allowlist rules in `repos/arashi-docs/scripts/check-canonical-docs-domain.ts`
+- [X] T018 [US2] Enforce exact canonical target for `[Documentation](...)` link in `repos/arashi-docs/scripts/check-readme-link.ts`
+- [X] T019 [P] [US2] Document canonical-link authoring policy and remediation steps in `repos/arashi-docs/docs/contributing/validation-troubleshooting.md`
+- [X] T020 [P] [US2] Document canonical-domain validation command usage in `repos/arashi-docs/README.md`
+- [X] T021 [US2] Add README docs-link drift guard to CI checks in `repos/arashi/.github/workflows/ci.yml`
+- [X] T022 [US2] Execute regression-check commands and capture results in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+
+**Checkpoint**: User Story 2 enforces canonical-domain policy for future edits.
+
+---
+
+## Phase 5: User Story 3 - Approve Migration with Evidence (Priority: P3)
+
+**Goal**: Provide release approvers with complete, auditable migration evidence including exceptions.
+
+**Independent Test**: Review the migration evidence and confirm it lists all updated references and any approved exceptions.
+
+### Implementation for User Story 3
+
+- [X] T023 [US3] Populate final updated-reference inventory by in-scope surface in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T024 [P] [US3] Populate approved exceptions (or explicit none) with owner and reason in `repos/arashi-docs/docs/contributing/docs-domain-exceptions.md`
+- [X] T025 [US3] Add release-approver checklist and sign-off fields in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T026 [US3] Cross-link scope, evidence, and exceptions artifacts in `repos/arashi-docs/docs/contributing/docs-domain-migration-scope.md`
+- [X] T027 [US3] Add audit-traceability pointer to evidence artifacts in `repos/arashi-docs/README.md`
+- [X] T028 [US3] Verify and record closure equation (`updated + approved exceptions = total target`) in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+
+**Checkpoint**: User Story 3 provides approver-ready migration evidence.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality pass and release-ready handoff across all stories.
+
+- [X] T029 [P] Run final deprecated-domain sweep for touched surfaces and record outcome in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T030 [P] Run full docs validation suite from `repos/arashi-docs/package.json` and append final run details to `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+- [X] T031 Update final implementation summary and handoff notes in `repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2.
+- **Phase 4 (US2)**: Depends on Phase 2; recommended after US1 so policy rules validate migrated canonical state.
+- **Phase 5 (US3)**: Depends on US1 completion and inputs from US2 checks.
+- **Phase 6 (Polish)**: Depends on all selected user stories being complete.
+
+### User Story Dependency Graph
+
+- `US1 (P1) -> US3 (P3)`
+- `US2 (P2) -> US3 (P3)`
+- `US1 (P1)` and `US2 (P2)` can proceed in parallel after foundational work, but sequence `US1` then `US2` is lower risk.
+
+### Within Each User Story
+
+- Update core files first.
+- Run story-specific validation checks.
+- Record evidence for independent acceptance before moving on.
+
+### Parallel Opportunities
+
+- Setup: `T003`, `T004` can run in parallel.
+- Foundational: `T006` and `T007` can run in parallel after `T005` scaffolding is ready.
+- US1: `T010`, `T011`, `T012`, and `T013` can run in parallel.
+- US2: `T019` and `T020` can run in parallel.
+- US3: `T024` can run in parallel with `T023` once evidence skeleton exists.
+- Polish: `T029` and `T030` can run in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Parallel file updates for US1
+Task: "T010 [US1] Replace Documentation URL in repos/arashi/README.md"
+Task: "T011 [US1] Replace canonical docs URL text in repos/arashi-docs/README.md"
+Task: "T012 [US1] Replace site URL in repos/arashi-docs/astro.config.mjs"
+Task: "T013 [US1] Replace troubleshooting URL in repos/arashi-docs/docs/contributing/validation-troubleshooting.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Parallel policy documentation updates for US2
+Task: "T019 [US2] Update contributor policy in repos/arashi-docs/docs/contributing/validation-troubleshooting.md"
+Task: "T020 [US2] Update canonical-domain validation docs in repos/arashi-docs/README.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Parallel evidence and exceptions updates for US3
+Task: "T023 [US3] Populate updated-reference inventory in repos/arashi-docs/docs/contributing/docs-domain-migration-evidence.md"
+Task: "T024 [US3] Populate approved exceptions in repos/arashi-docs/docs/contributing/docs-domain-exceptions.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1).
+3. Validate US1 independently with the spec-defined audit criteria.
+4. If needed, release MVP with canonical URLs standardized.
+
+### Incremental Delivery
+
+1. Deliver US1 to standardize current links.
+2. Deliver US2 to prevent regressions.
+3. Deliver US3 to finalize auditability and release approval evidence.
+4. Finish with Phase 6 polish and final validation.
+
+### Parallel Team Strategy
+
+1. One contributor handles enforcement scripts/workflows (`T005`-`T008`).
+2. One contributor handles canonical URL content replacements (`T010`-`T014`).
+3. One contributor handles audit artifacts and sign-off docs (`T023`-`T028`).
+
+---
+
+## Notes
+
+- [P] tasks touch separate files and avoid incomplete-task dependencies.
+- [USx] labels map each story task directly to spec scenarios for traceability.
+- Each user story has independent acceptance criteria copied from `spec.md`.
+- All task lines follow the required checklist format.


### PR DESCRIPTION
## Summary
- capture the full spec-kit workflow for issue #86 in `specs/035-update-docs-domain`
- add the feature spec, plan, research, data model, contracts, checklist, and completed task execution log
- update `AGENTS.md` with the new technology/context entries for this feature

## Validation
- specification quality checklist completed with all items passing