### PR TITLE
specs: add install script feature artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ config-mgmt/
 - Filesystem content and repository metadata only (no application database) (035-update-docs-domain)
 - TypeScript 5.9 (CLI), Markdown (CommonMark), Astro config/CSS, SVG/ICO static assets + Bun runtime, commander (CLI help rendering), Astro + Starlight (docs site) (036-add-logo-assets)
 - Filesystem assets and source files in repository worktrees (no application database) (036-add-logo-assets)
+- Shell script (POSIX/Bash) for installer bootstrap, TypeScript 5.9 + Bun runtime for CLI/release support scripts, Markdown (CommonMark) for README and documentation, Astro/Starlight content frontmatter for landing hero conten + GitHub Releases distribution assets, npm global distribution (`arashi` package), Bun build/release scripts, Astro/Starlight docs site toolchain (038-add-install-script)
+- Filesystem content in repository worktrees; release artifacts in GitHub Releases (no application database) (038-add-install-script)
 
 - Markdown documentation (N/A - no code implementation) + Git 2.5+ (subject of research) (002-git-worktree-research)
 
@@ -108,9 +110,9 @@ tests/
 Markdown documentation (N/A - no code implementation): Follow standard conventions
 
 ## Recent Changes
+- 038-add-install-script: Added Shell script (POSIX/Bash) for installer bootstrap, TypeScript 5.9 + Bun runtime for CLI/release support scripts, Markdown (CommonMark) for README and documentation, Astro/Starlight content frontmatter for landing hero conten + GitHub Releases distribution assets, npm global distribution (`arashi` package), Bun build/release scripts, Astro/Starlight docs site toolchain
 - 036-add-logo-assets: Added TypeScript 5.9 (CLI), Markdown (CommonMark), Astro config/CSS, SVG/ICO static assets + Bun runtime, commander (CLI help rendering), Astro + Starlight (docs site)
 - 035-update-docs-domain: Added Markdown (CommonMark), TypeScript 5.9, JavaScript module config, YAML workflow definitions + Bun runtime scripts, Astro/Starlight site configuration, GitHub Actions workflows, Netlify publication pipeline
-- 034-init-docs-site: Added Markdown (CommonMark) for content, TypeScript-based static site toolchain for build/runtime orchestration + Astro, Starlight, Netlify for hosting/deploy previews, GitHub Actions for validation and link health checks
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/038-add-install-script/checklists/requirements.md
+++ b/specs/038-add-install-script/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Install Script and Onboarding Instructions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-11
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1: all checklist items passed.
+- No outstanding clarification markers.

--- a/specs/038-add-install-script/contracts/install-onboarding.openapi.yaml
+++ b/specs/038-add-install-script/contracts/install-onboarding.openapi.yaml
@@ -1,0 +1,430 @@
+openapi: 3.1.0
+info:
+  title: Install Onboarding Contract
+  version: 1.0.0
+  description: |
+    Planning contract for defining official Arashi installation methods,
+    publishing synchronized onboarding instructions across README/docs/hero,
+    and validating first-run installation outcomes.
+servers:
+  - url: https://onboarding.arashi.local
+
+paths:
+  /installation/methods:
+    get:
+      summary: List active installation methods
+      operationId: listInstallationMethods
+      responses:
+        '200':
+          description: Active installation methods returned
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [methods]
+                properties:
+                  methods:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InstallationMethod'
+    put:
+      summary: Create or update an official installation method
+      operationId: upsertInstallationMethod
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstallationMethodRequest'
+      responses:
+        '200':
+          description: Installation method updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstallationMethod'
+
+  /installation/release-binding:
+    put:
+      summary: Configure curl installer release binding and fallback behavior
+      operationId: configureReleaseBinding
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReleaseBindingRequest'
+      responses:
+        '200':
+          description: Release binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReleaseBinding'
+
+  /installation/surfaces/{surfaceId}/instructions:
+    parameters:
+      - name: surfaceId
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [readme, docs-getting-started, docs-landing-hero]
+    get:
+      summary: Get installation instructions for a surface
+      operationId: getSurfaceInstructions
+      responses:
+        '200':
+          description: Surface instructions returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GuidanceSurface'
+    put:
+      summary: Define installation instructions for a surface
+      operationId: upsertSurfaceInstructions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GuidanceSurfaceRequest'
+      responses:
+        '200':
+          description: Surface instructions updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GuidanceSurface'
+
+  /installation/access-policy:
+    put:
+      summary: Define install onboarding access policy
+      operationId: setInstallAccessPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccessPolicyRequest'
+      responses:
+        '200':
+          description: Access policy updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessPolicy'
+
+  /installation/consistency-checks:
+    post:
+      summary: Run consistency check across install surfaces
+      operationId: runInstallConsistencyCheck
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsistencyCheckRequest'
+      responses:
+        '201':
+          description: Consistency check result created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsistencyCheckResult'
+
+  /installation/outcomes:
+    post:
+      summary: Record first-run installation outcome
+      operationId: recordInstallOutcome
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FirstRunOutcomeRequest'
+      responses:
+        '201':
+          description: Installation outcome recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FirstRunOutcome'
+
+components:
+  schemas:
+    InstallationMethodRequest:
+      type: object
+      required:
+        [methodType, displayName, commandTemplate, prerequisites, verificationCommand, troubleshootingReference]
+      properties:
+        methodType:
+          type: string
+          enum: [curl-script, npm-global]
+        displayName:
+          type: string
+        commandTemplate:
+          type: string
+        prerequisites:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        verificationCommand:
+          type: string
+        troubleshootingReference:
+          type: string
+
+    InstallationMethod:
+      type: object
+      required:
+        [methodId, methodType, displayName, commandTemplate, prerequisites, verificationCommand, status]
+      properties:
+        methodId:
+          type: string
+        methodType:
+          type: string
+          enum: [curl-script, npm-global]
+        displayName:
+          type: string
+        commandTemplate:
+          type: string
+        prerequisites:
+          type: array
+          items:
+            type: string
+        verificationCommand:
+          type: string
+        troubleshootingReference:
+          type: string
+        status:
+          type: string
+          enum: [draft, approved, active, deprecated]
+
+    ReleaseBindingRequest:
+      type: object
+      required:
+        [defaultVersionPolicy, supportsVersionPin, platformAssetMap, integrityPolicy, fallbackMethodId]
+      properties:
+        defaultVersionPolicy:
+          type: string
+          enum: [latest-stable, pinned-required]
+        supportsVersionPin:
+          type: boolean
+        platformAssetMap:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/PlatformAsset'
+        integrityPolicy:
+          type: string
+          enum: [checksum-required, checksum-optional]
+        fallbackMethodId:
+          type: string
+
+    ReleaseBinding:
+      type: object
+      required:
+        [bindingId, defaultVersionPolicy, supportsVersionPin, platformAssetMap, integrityPolicy, fallbackMethodId, status]
+      properties:
+        bindingId:
+          type: string
+        defaultVersionPolicy:
+          type: string
+          enum: [latest-stable, pinned-required]
+        supportsVersionPin:
+          type: boolean
+        platformAssetMap:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformAsset'
+        integrityPolicy:
+          type: string
+          enum: [checksum-required, checksum-optional]
+        fallbackMethodId:
+          type: string
+        status:
+          type: string
+          enum: [draft, approved, active, retired]
+
+    PlatformAsset:
+      type: object
+      required: [platformKey, assetName]
+      properties:
+        platformKey:
+          type: string
+          enum: [macos-arm64, linux-x64, windows-x64]
+        assetName:
+          type: string
+
+    GuidanceSurfaceRequest:
+      type: object
+      required:
+        [repository, path, methodIds, includesPrerequisites, includesVerification, includesTroubleshooting, includesNextStep]
+      properties:
+        repository:
+          type: string
+        path:
+          type: string
+        methodIds:
+          type: array
+          minItems: 2
+          items:
+            type: string
+        includesPrerequisites:
+          type: boolean
+        includesVerification:
+          type: boolean
+        includesTroubleshooting:
+          type: boolean
+        includesNextStep:
+          type: boolean
+
+    GuidanceSurface:
+      type: object
+      required:
+        [surfaceId, surfaceType, repository, path, methodIds, includesPrerequisites, includesVerification, includesTroubleshooting, includesNextStep, status]
+      properties:
+        surfaceId:
+          type: string
+        surfaceType:
+          type: string
+          enum: [readme, docs-getting-started, docs-landing-hero]
+        repository:
+          type: string
+        path:
+          type: string
+        methodIds:
+          type: array
+          items:
+            type: string
+        includesPrerequisites:
+          type: boolean
+        includesVerification:
+          type: boolean
+        includesTroubleshooting:
+          type: boolean
+        includesNextStep:
+          type: boolean
+        status:
+          type: string
+          enum: [draft, approved, active, superseded]
+
+    AccessPolicyRequest:
+      type: object
+      required: [allowsAnonymousInstall]
+      properties:
+        allowsAnonymousInstall:
+          type: boolean
+        notes:
+          type: string
+
+    AccessPolicy:
+      type: object
+      required: [policyId, allowsAnonymousInstall, status]
+      properties:
+        policyId:
+          type: string
+        allowsAnonymousInstall:
+          type: boolean
+        notes:
+          type: string
+        status:
+          type: string
+          enum: [draft, active, retired]
+
+    ConsistencyCheckRequest:
+      type: object
+      required: [surfaces]
+      properties:
+        surfaces:
+          type: array
+          minItems: 3
+          items:
+            type: string
+            enum: [readme, docs-getting-started, docs-landing-hero]
+
+    ConsistencyCheckResult:
+      type: object
+      required:
+        [checkId, checkedAt, surfacesChecked, commandParityPass, prerequisitesPass, verificationPass, troubleshootingPass, nextStepPass, outcome]
+      properties:
+        checkId:
+          type: string
+        checkedAt:
+          type: string
+          format: date-time
+        surfacesChecked:
+          type: array
+          items:
+            type: string
+        commandParityPass:
+          type: boolean
+        prerequisitesPass:
+          type: boolean
+        verificationPass:
+          type: boolean
+        troubleshootingPass:
+          type: boolean
+        nextStepPass:
+          type: boolean
+        outcome:
+          type: string
+          enum: [pass, fail]
+
+    FirstRunOutcomeRequest:
+      type: object
+      required: [methodId, surfaceId, startedAt, verificationPassed, resolvedWithFallback, nextStepCompleted]
+      properties:
+        methodId:
+          type: string
+        surfaceId:
+          type: string
+          enum: [readme, docs-getting-started, docs-landing-hero]
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+        durationSeconds:
+          type: integer
+          minimum: 0
+        verificationPassed:
+          type: boolean
+        failureCategory:
+          type: string
+          enum: [missing-prerequisite, permission, network, unsupported-platform, other]
+        resolvedWithFallback:
+          type: boolean
+        nextStepCompleted:
+          type: boolean
+
+    FirstRunOutcome:
+      type: object
+      required:
+        [outcomeId, methodId, surfaceId, startedAt, verificationPassed, resolvedWithFallback, nextStepCompleted]
+      properties:
+        outcomeId:
+          type: string
+        methodId:
+          type: string
+        surfaceId:
+          type: string
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+        durationSeconds:
+          type: integer
+        verificationPassed:
+          type: boolean
+        failureCategory:
+          type: string
+          enum: [missing-prerequisite, permission, network, unsupported-platform, other]
+        resolvedWithFallback:
+          type: boolean
+        nextStepCompleted:
+          type: boolean

--- a/specs/038-add-install-script/data-model.md
+++ b/specs/038-add-install-script/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Install Script and Onboarding Instructions
+
+**Feature**: 038-add-install-script  
+**Date**: 2026-02-11
+
+## Overview
+
+This feature defines planning-level entities for managing two official installation methods, publishing consistent onboarding guidance across landing/docs/README surfaces, and validating first-run installation outcomes.
+
+## Entities
+
+### 1. Installation Method
+
+**Description**: A user-selectable official installation path (curl script or npm) with command format, prerequisites, and expected verification behavior.
+
+**Fields**:
+
+- `method_id` (string, required)
+- `method_type` (enum, required): `curl-script` | `npm-global`
+- `display_name` (string, required)
+- `command_template` (string, required)
+- `prerequisites` (array of string, required)
+- `verification_command` (string, required)
+- `troubleshooting_reference` (string, required)
+- `status` (enum, required): `draft` | `approved` | `active` | `deprecated`
+
+**Validation Rules**:
+
+- Exactly one active `curl-script` method and one active `npm-global` method must exist for this feature scope.
+- `command_template` must be copy-ready and executable as a single command.
+- `verification_command` must confirm an installed state observable by end users.
+
+### 2. Installation Guidance Surface
+
+**Description**: A public-facing content surface where installation instructions are displayed.
+
+**Fields**:
+
+- `surface_id` (string, required)
+- `surface_type` (enum, required): `readme` | `docs-getting-started` | `docs-landing-hero`
+- `repository` (string, required)
+- `path` (string, required)
+- `method_ids` (array of string, required)
+- `includes_prerequisites` (boolean, required)
+- `includes_verification` (boolean, required)
+- `includes_troubleshooting` (boolean, required)
+- `includes_next_step` (boolean, required)
+- `status` (enum, required): `draft` | `approved` | `active` | `superseded`
+
+**Validation Rules**:
+
+- All three required surfaces must include both installation methods.
+- `docs-landing-hero` must present both method commands at first view.
+- At least one canonical detailed surface (`docs-getting-started`) must include prerequisites, verification, troubleshooting, and next-step guidance.
+
+### 3. Install Script Release Binding
+
+**Description**: Mapping between the curl installer behavior and release artifacts used to complete installation.
+
+**Fields**:
+
+- `binding_id` (string, required)
+- `default_version_policy` (enum, required): `latest-stable` | `pinned-required`
+- `supports_version_pin` (boolean, required)
+- `platform_asset_map` (array, required)
+- `integrity_policy` (enum, required): `checksum-required` | `checksum-optional`
+- `fallback_method_id` (string, required)
+- `status` (enum, required): `draft` | `approved` | `active` | `retired`
+
+**Validation Rules**:
+
+- Every supported platform in scope must map to a release asset.
+- `integrity_policy` must not be weaker than `checksum-required` when method type is `curl-script`.
+- `fallback_method_id` must reference the active npm method.
+
+### 4. First-Run Outcome
+
+**Description**: Observable result of a first-time installation attempt, used to track success criteria and support quality checks.
+
+**Fields**:
+
+- `outcome_id` (string, required)
+- `method_id` (string, required)
+- `surface_id` (string, required)
+- `started_at` (date-time, required)
+- `completed_at` (date-time, optional)
+- `duration_seconds` (integer, optional)
+- `verification_passed` (boolean, required)
+- `failure_category` (enum, optional): `missing-prerequisite` | `permission` | `network` | `unsupported-platform` | `other`
+- `resolved_with_fallback` (boolean, required)
+- `next_step_completed` (boolean, required)
+
+**Validation Rules**:
+
+- Successful outcomes require `verification_passed=true` and populated `completed_at`.
+- `duration_seconds` is required for successful outcomes used in KPI calculation.
+- If `resolved_with_fallback=true`, outcome must reference a different method than initial attempted method.
+
+## Relationships
+
+- One `Installation Method` can appear on many `Installation Guidance Surface` records.
+- One `Install Script Release Binding` references one primary curl method and one fallback npm method.
+- One `First-Run Outcome` references one `Installation Method` and one `Installation Guidance Surface`.
+- Each required guidance surface must reference both active installation methods.
+
+## State Transitions
+
+### Installation Method
+
+`draft -> approved -> active -> deprecated`
+
+### Installation Guidance Surface
+
+`draft -> approved -> active -> superseded`
+
+### Install Script Release Binding
+
+`draft -> approved -> active -> retired`
+
+### First-Run Outcome
+
+`started -> verified` or `started -> failed` or `started -> fallback-completed`

--- a/specs/038-add-install-script/plan.md
+++ b/specs/038-add-install-script/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Install Script and Onboarding Instructions
+
+**Branch**: `038-add-install-script` | **Date**: 2026-02-11 | **Spec**: `specs/038-add-install-script/spec.md`
+**Input**: Feature specification from `specs/038-add-install-script/spec.md`
+
+## Summary
+
+Add a one-command curl installation path alongside the existing npm path, then align all first-touch onboarding surfaces so users can discover both methods immediately and follow consistent prerequisite, verification, troubleshooting, and next-step guidance. The implementation strategy keeps one canonical install guidance contract across `repos/arashi` and `repos/arashi-docs`, with release-aware script behavior and explicit consistency checks to prevent docs drift.
+
+## Technical Context
+
+**Language/Version**: Shell script (POSIX/Bash) for installer bootstrap, TypeScript 5.9 + Bun runtime for CLI/release support scripts, Markdown (CommonMark) for README and documentation, Astro/Starlight content frontmatter for landing hero content  
+**Primary Dependencies**: GitHub Releases distribution assets, npm global distribution (`arashi` package), Bun build/release scripts, Astro/Starlight docs site toolchain  
+**Storage**: Filesystem content in repository worktrees; release artifacts in GitHub Releases (no application database)  
+**Testing**: `bun run lint`, `bun test`, `bun run build` in `repos/arashi`; `bun run validate`, `bun run build` in `repos/arashi-docs`; manual acceptance checks for curl install flow, npm install flow, hero visibility, and command consistency  
+**Target Platform**: First-time CLI users on macOS ARM64, Linux x64, and Windows x64 (with platform-appropriate installation guidance), plus docs consumers on modern desktop/mobile browsers  
+**Project Type**: Multi-repository CLI distribution + documentation/landing-page onboarding update  
+**Performance Goals**: Preserve spec outcomes: >=90% install completion within 5 minutes, >=95% first-attempt verification success, and full command-consistency checks across hero/docs/README in each release cycle  
+**Constraints**: One-command curl path and npm path must both be copy-ready; no account gate for initial install; install messaging must include prerequisites, verification, troubleshooting, and next action; command text must stay synchronized across all in-scope surfaces  
+**Scale/Scope**: Two installation methods, three high-visibility surfaces (`repos/arashi/README.md`, `repos/arashi-docs/docs/getting-started/index.md`, `repos/arashi-docs/docs/index.md` hero), plus supporting install-script/release workflow touchpoints in `repos/arashi`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Single-file executable: preserved; install path still distributes existing compiled binaries and wrapper behavior - Pass
+- II. Automatic worktree management: unchanged; feature is installation/onboarding only - Pass
+- III. Error recovery and rollback: unchanged for CLI worktree operations; installer plan adds explicit failure messaging and safe retry expectations - Pass
+- IV. User-centric interface: improved with dual install methods, clear prerequisites, and troubleshooting guidance - Pass
+- V. Minimalist configuration: preserved; no new mandatory configuration files introduced - Pass
+- VI. Cross-platform compatibility: addressed by platform-aware install guidance and fallback paths per supported OS/arch matrix - Pass
+- VII. Test coverage: implementation plan includes required lint/test/build gates plus onboarding acceptance checks across repositories - Pass
+- VIII. Semantic versioning: preserved; release pipeline continues semantic-release tagging and binary publication - Pass
+- IX. Hook system: unaffected; no lifecycle hook behavior changes - Pass
+- X. Performance standards: CLI runtime performance unaffected; onboarding improvements target faster successful first install - Pass
+
+**Gate Result (Pre-Research)**: Pass.
+
+**Post-Design Re-check**: Pass (research, data model, contracts, and quickstart keep constitutional principles intact; no exceptions required).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/038-add-install-script/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── install-onboarding.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+repos/arashi/
+├── README.md
+├── docs/
+│   └── INSTALLATION.md
+├── scripts/
+│   └── install.sh
+├── .releaserc.json
+└── .github/
+    └── workflows/
+        └── release.yml
+
+repos/arashi-docs/
+├── docs/
+│   ├── index.md
+│   └── getting-started/
+│       └── index.md
+└── scripts/
+    └── (existing validation scripts leveraged for checks)
+```
+
+**Structure Decision**: Keep planning artifacts in `specs/038-add-install-script` and implement install and onboarding updates in the existing implementation repositories: install/release/README behavior in `repos/arashi` and landing/docs guidance in `repos/arashi-docs`.
+
+## Complexity Tracking
+
+No constitutional violations identified; no complexity exceptions required.

--- a/specs/038-add-install-script/quickstart.md
+++ b/specs/038-add-install-script/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Install Script and Onboarding Instructions
+
+**Feature**: 038-add-install-script  
+**Audience**: Maintainers implementing install flow and onboarding content updates  
+**Last Updated**: 2026-02-11
+
+## Goal
+
+Ship two clear first-run install paths (curl script and npm) and present them consistently in README, docs onboarding, and landing hero so users can install and verify quickly.
+
+## Prerequisites
+
+- Workspace repositories are synced under `repos/`.
+- You can edit these repositories:
+  - `repos/arashi`
+  - `repos/arashi-docs`
+- You can run quality gates in both repositories.
+
+## Step 1: Define Canonical Install Commands
+
+1. Finalize the canonical curl one-command install text.
+2. Finalize npm global install command text.
+3. Define one verification command and one immediate next-step command shared across surfaces.
+
+## Step 2: Implement curl Install Path
+
+1. Add or update the installer script in `repos/arashi` as the canonical direct-install mechanism.
+2. Ensure it covers supported platform mapping and clear failure messaging.
+3. Ensure reruns are safe and predictable.
+
+## Step 3: Align Release Binding for Installer
+
+1. Confirm installer references release assets that align with current semantic-release outputs.
+2. Ensure integrity metadata and fallback behavior are documented and wired into release expectations.
+3. Ensure installer and release artifact naming stay synchronized.
+
+## Step 4: Update README Installation Surface
+
+1. Update `repos/arashi/README.md` installation section with both curl and npm methods.
+2. Include prerequisites, verification, and fallback troubleshooting entry points.
+3. Keep wording and command text consistent with docs onboarding content.
+
+## Step 5: Update Docs Onboarding Surface
+
+1. Update `repos/arashi-docs/docs/getting-started/index.md` with dual install methods.
+2. Include prerequisite checks, verification step, troubleshooting guidance, and clear next action.
+3. Keep this page as canonical detailed guidance for first-time users.
+
+## Step 6: Update Landing Hero Visibility
+
+1. Update `repos/arashi-docs/docs/index.md` hero content so both install methods are immediately visible.
+2. Keep hero presentation concise while linking to complete onboarding details.
+3. Verify mobile and desktop readability for copy-ready commands in hero context.
+
+## Step 7: Validate Consistency and Quality
+
+1. Verify command parity across:
+   - `repos/arashi/README.md`
+   - `repos/arashi-docs/docs/getting-started/index.md`
+   - `repos/arashi-docs/docs/index.md`
+2. Verify both install methods include matching verification and troubleshooting outcomes.
+3. Perform manual acceptance checks for both methods from clean first-run conditions.
+
+## Step 8: Run Required Quality Gates
+
+In `repos/arashi`:
+
+1. `bun run lint`
+2. `bun test`
+3. `bun run build`
+
+In `repos/arashi-docs`:
+
+1. `bun run validate`
+2. `bun run build`
+
+## Expected Outcome
+
+Users can discover either install method from the landing hero, follow complete instructions in docs/README, and complete verified first-run install without account setup.

--- a/specs/038-add-install-script/research.md
+++ b/specs/038-add-install-script/research.md
@@ -1,0 +1,121 @@
+# Research: Install Script and Onboarding Instructions
+
+**Date**: 2026-02-11  
+**Feature**: 038-add-install-script  
+**Purpose**: Resolve planning decisions for installer behavior, dual-method onboarding content, and cross-surface consistency.
+
+## 1) One-Command curl Install Behavior
+
+### Decision
+
+Use a thin, one-command curl installer as an official direct-install path, with default latest-stable install and optional version pinning.
+
+### Rationale
+
+- One-command bootstrap aligns with issue intent and reduces first-run friction.
+- Latest-by-default supports simple onboarding, while pinned version support enables reproducible team/CI workflows.
+- A thin script minimizes maintenance and keeps canonical install behavior tied to release assets.
+
+### Alternatives considered
+
+- Latest-only installer: rejected due to weaker reproducibility for teams.
+- Pinned-only installer: rejected due to higher friction for first-time users.
+- npm-only onboarding: rejected because the feature explicitly requires curl and npm options.
+
+## 2) Installer Integrity and Reliability
+
+### Decision
+
+Installer flow should include strict download behavior, platform-aware asset selection, and checksum verification before final placement.
+
+### Rationale
+
+- Integrity checks reduce tampering risk for curl-based installation.
+- Platform detection with explicit unsupported-matrix messaging prevents ambiguous failures.
+- Atomic replacement and rerunnable behavior improve reliability for retries and automation.
+
+### Alternatives considered
+
+- No checksum verification: rejected due to weaker supply-chain posture.
+- API-only release resolution: rejected as unnecessary complexity for baseline onboarding.
+- Always reinstall on every run: rejected due to avoidable drift and bandwidth cost.
+
+## 3) Canonical Placement of Install Instructions
+
+### Decision
+
+Use `repos/arashi-docs/docs/getting-started/index.md` as canonical onboarding detail for dual install paths, with `repos/arashi-docs/docs/index.md` hero exposing both methods at first glance and routing users to complete guidance.
+
+### Rationale
+
+- Getting Started already owns first-run setup and keeps detailed instructions in one maintained location.
+- Landing hero visibility satisfies discoverability requirement while preserving concise splash layout.
+- This keeps onboarding consistent with docs navigation conventions and avoids fragmented guidance.
+
+### Alternatives considered
+
+- Put full install instructions only in splash hero: rejected because hero content becomes crowded and harder to maintain.
+- Keep install details only in README: rejected because docs site is the primary guided onboarding surface.
+- Add separate new install page immediately: deferred because current Getting Started page can absorb scope without extra navigation overhead.
+
+## 4) Multi-Surface Consistency Model
+
+### Decision
+
+Treat install commands and expected outcomes as a governed content contract across three surfaces: `repos/arashi/README.md`, `repos/arashi-docs/docs/getting-started/index.md`, and `repos/arashi-docs/docs/index.md` hero.
+
+### Rationale
+
+- The same user can enter from GitHub README or docs site; drift between surfaces creates failed installs and support load.
+- Contract-style validation criteria make acceptance repeatable and auditable.
+- Consistency directly supports FR-006 and SC-003.
+
+### Alternatives considered
+
+- Informal/manual spot checks only: rejected due to high drift risk over time.
+- Single-source only (remove one entry point): rejected because both README and docs are intentional acquisition surfaces.
+
+## 5) Fallback and Troubleshooting Expectations
+
+### Decision
+
+Document explicit fallback guidance: if curl path fails, users can use npm path; if npm prerequisites are missing, users can use curl path or platform-specific manual route where needed.
+
+### Rationale
+
+- Dual-path fallbacks maximize successful installs in varied environments.
+- Clear prerequisite and troubleshooting guidance reduces first-run confusion.
+- Matches requested behavior for common failures and no-account onboarding.
+
+### Alternatives considered
+
+- One fallback path only: rejected because it does not cover users with constrained environments.
+- Long troubleshooting guide only in deep docs: rejected because first-run onboarding needs immediate actionable recovery steps.
+
+## 6) Release Integration for Installer Artifacts
+
+### Decision
+
+Keep installer logic aligned with semantic-release output and ensure install-related artifacts (binary mapping and integrity metadata) are published in the same release flow as binaries.
+
+### Rationale
+
+- Existing release automation is already the single source of version truth.
+- Publishing installer artifacts with binaries prevents version skew.
+- Improves trust and consistency for both curl and npm users.
+
+### Alternatives considered
+
+- Separate post-release artifact generation: rejected due to additional failure modes and drift.
+- Manual artifact publishing: rejected due to repeatability and auditability concerns.
+
+## Result
+
+All Phase 0 unknowns are resolved:
+
+- Installer mode, integrity strategy, and platform behavior are defined.
+- Canonical docs and hero placement strategy for dual install options is defined.
+- Cross-surface consistency and fallback policies are defined.
+- Release integration expectations for installer-related assets are defined.
+
+No unresolved `NEEDS CLARIFICATION` items remain.

--- a/specs/038-add-install-script/spec.md
+++ b/specs/038-add-install-script/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Install Script and Onboarding Instructions
+
+**Feature Branch**: `038-add-install-script`  
+**Created**: 2026-02-11  
+**Status**: Draft  
+**Input**: User description: "https://github.com/corwinm/arashi-arashi/issues/90"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Install via curl command (Priority: P1)
+
+A first-time user wants a single command they can copy and run to install the tool without reading long setup steps.
+
+**Why this priority**: The request centers on adding an install script, and this is the fastest path from discovery to first successful use.
+
+**Independent Test**: Can be fully tested by following the documented curl-based command from the landing page or docs and confirming the user reaches a successful installed state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the landing page, **When** they copy and run the curl-based install command, **Then** they can complete installation and see a clear verification step.
+2. **Given** a user follows the curl-based install instructions, **When** a prerequisite is missing, **Then** the instructions clearly explain what is missing and how to proceed.
+
+---
+
+### User Story 2 - Install via npm command (Priority: P2)
+
+A user who prefers package-manager workflows wants an npm install path that is as easy to follow as the curl option.
+
+**Why this priority**: The issue explicitly asks for npm as an alternative install path, which broadens adoption for users who avoid shell scripts.
+
+**Independent Test**: Can be fully tested by following the npm install instructions from docs and confirming the user reaches the same successful installed state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the docs install page, **When** they use the npm install path, **Then** installation completes and they can run a verification command.
+2. **Given** npm is unavailable on the user's environment, **When** they attempt the npm path, **Then** the instructions direct them to a workable alternative.
+
+---
+
+### User Story 3 - Choose install method from hero section (Priority: P3)
+
+A user evaluating the project wants to immediately see available install methods in the landing page hero so they can start without hunting through documentation.
+
+**Why this priority**: The issue requires hero-level visibility for both install options, improving discoverability during first visit.
+
+**Independent Test**: Can be tested by loading the landing page and verifying the hero clearly presents both curl and npm install options with actionable commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user lands on the homepage, **When** they view the hero section, **Then** they can see both curl and npm install commands without navigating away.
+2. **Given** a user selects either method from the hero, **When** they follow the linked guidance, **Then** they are taken to complete, matching install instructions.
+
+---
+
+### Edge Cases
+
+- What happens when a user copies a command from an outdated cached page version?
+- How does the system handle install script download failures caused by connectivity or permissions issues?
+- What happens when the user environment supports neither curl nor npm?
+- How does guidance stay consistent when install commands are updated in one location but not the other?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide an official curl-based installation path that users can execute with a single copied command.
+- **FR-002**: The system MUST provide an official npm-based installation path that achieves the same installation outcome as the curl path.
+- **FR-003**: The landing page hero MUST display both curl and npm installation options in a copy-ready format.
+- **FR-004**: Documentation MUST include prerequisite checks and a post-install verification step for each installation method.
+- **FR-005**: Installation guidance MUST include troubleshooting steps for common first-run failures (missing prerequisites, command failure, or permission issues).
+- **FR-006**: Installation commands and expected outcomes MUST remain consistent between the landing page and documentation.
+- **FR-007**: Users MUST be able to complete initial installation without account creation or additional onboarding gates.
+- **FR-008**: The system MUST provide a clear next step after install (for example, where to find usage help) so users can move from install to first use.
+
+### Key Entities *(include if feature involves data)*
+
+- **Installation Method**: A user-selectable path for setup (curl or npm), including command text, prerequisites, and verification expectations.
+- **Installation Guidance**: Canonical user-facing instructions for each method, including command, verification, and troubleshooting content.
+- **First-Run Outcome**: The observable result of a completed install flow, including successful verification and clear next action.
+
+### Assumptions
+
+- This feature targets first-time users installing from project-controlled channels.
+- Both installation methods are intended to be equally valid choices for supported user environments.
+- "Similar to OpenCode's install script" means one-command simplicity and strong onboarding clarity, not strict behavioral parity.
+
+### Dependencies
+
+- Public distribution channels for both installation methods remain reachable to first-time users.
+- The landing page and documentation content can be updated and published in the same release window to avoid mismatched guidance.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At least 90% of first-time users can complete installation in under 5 minutes using either documented method.
+- **SC-002**: At least 95% of first-time users can complete the post-install verification step on their first attempt.
+- **SC-003**: 100% of landing page hero and install documentation reviews show both curl and npm methods present with copy-ready commands.
+- **SC-004**: At least 85% of surveyed new users rate installation instructions as clear or very clear.
+- **SC-005**: Installation-related support requests from new users decrease by at least 30% in the first 30 days after release versus the prior 30-day period.

--- a/specs/038-add-install-script/tasks.md
+++ b/specs/038-add-install-script/tasks.md
@@ -1,0 +1,201 @@
+# Tasks: Install Script and Onboarding Instructions
+
+**Input**: Design documents from `/specs/038-add-install-script/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/install-onboarding.openapi.yaml`, `quickstart.md`
+
+**Tests**: No new automated test files were explicitly requested in the feature spec; this plan uses required lint/build/test/validate gates plus manual acceptance checks from `quickstart.md`.
+
+**Organization**: Tasks are grouped by user story so each story is independently implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete tasks)
+- **[Story]**: User story label (`[US1]`, `[US2]`, `[US3]`)
+- Every task includes exact file path(s)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create shared scaffolding for installer and consistency tooling.
+
+- [X] T001 Create installer script scaffold with strict shell options in `repos/arashi/scripts/install.sh`
+- [X] T002 Create checksum generation helper for release artifacts in `repos/arashi/scripts/generate-checksums.sh`
+- [X] T003 [P] Create install command parity checker scaffold in `repos/arashi-docs/scripts/check-install-command-parity.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add release and validation foundations required by all user stories.
+
+**⚠️ CRITICAL**: Complete this phase before starting user story implementation.
+
+- [X] T004 Wire checksum artifact publishing into release config in `repos/arashi/.releaserc.json`
+- [X] T005 Update release workflow to generate and publish checksum manifest in `repos/arashi/.github/workflows/release.yml`
+- [X] T006 [P] Add install command parity validation script implementation in `repos/arashi-docs/scripts/check-install-command-parity.ts`
+- [X] T007 Integrate install command parity check into docs validation scripts in `repos/arashi-docs/package.json`
+- [X] T008 Integrate install command parity step into CI validation in `repos/arashi-docs/.github/workflows/docs-validate.yml`
+- [X] T009 [P] Add install consistency review checklist items in `repos/arashi-docs/docs/contributing/review-checklist.md`
+
+**Checkpoint**: Release + validation foundation is ready; user stories can proceed.
+
+---
+
+## Phase 3: User Story 1 - Install via curl command (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver a one-command curl install path with prerequisites, verification, and troubleshooting.
+
+**Independent Test**: Follow curl install command from landing/docs path, complete install, and run verification command successfully.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Implement platform detection and asset mapping logic in `repos/arashi/scripts/install.sh`
+- [X] T011 [US1] Implement version selection, download, and checksum verification flow in `repos/arashi/scripts/install.sh`
+- [X] T012 [US1] Implement atomic install placement and clear error/fallback messaging in `repos/arashi/scripts/install.sh`
+- [X] T013 [P] [US1] Add curl install command, prerequisites, and verification steps in `repos/arashi/README.md`
+- [X] T014 [P] [US1] Add curl-path troubleshooting and fallback guidance in `repos/arashi/docs/INSTALLATION.md`
+- [X] T015 [US1] Document installer-release binding behavior and checksum expectations in `repos/arashi/docs/INSTALLATION.md`
+
+**Checkpoint**: User Story 1 is independently functional and demonstrable (MVP).
+
+---
+
+## Phase 4: User Story 2 - Install via npm command (Priority: P2)
+
+**Goal**: Deliver npm install guidance that is equivalent to curl path and includes fallback behavior.
+
+**Independent Test**: Follow npm install instructions from docs, verify install, and confirm fallback guidance is actionable when npm is unavailable.
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Align npm install and verification command language in `repos/arashi/README.md`
+- [X] T017 [US2] Update npm installation flow with fallback to curl/manual path in `repos/arashi-docs/docs/getting-started/index.md`
+- [X] T018 [US2] Add prerequisites and no-account onboarding policy text in `repos/arashi-docs/docs/getting-started/index.md`
+- [X] T019 [US2] Add npm failure troubleshooting paths in `repos/arashi/docs/INSTALLATION.md`
+- [X] T020 [US2] Align troubleshooting and next-step wording between npm and curl methods in `repos/arashi-docs/docs/getting-started/index.md`
+
+**Checkpoint**: User Stories 1 and 2 both work independently with consistent outcomes.
+
+---
+
+## Phase 5: User Story 3 - Choose install method from hero section (Priority: P3)
+
+**Goal**: Make both install methods immediately visible and actionable from the landing hero.
+
+**Independent Test**: Open docs landing page and confirm hero presents copy-ready curl and npm methods with links to complete guidance.
+
+### Implementation for User Story 3
+
+- [X] T021 [US3] Update landing hero content to show both install commands in `repos/arashi-docs/docs/index.md`
+- [X] T022 [US3] Add hero actions linking to install detail anchors in `repos/arashi-docs/docs/index.md`
+- [X] T023 [US3] Add/adjust install section anchors for hero links in `repos/arashi-docs/docs/getting-started/index.md`
+- [X] T024 [US3] Apply hero layout styling for readable dual-command blocks in `repos/arashi-docs/src/styles/theme.css`
+- [X] T025 [US3] Align hero wording with README/docs install terminology in `repos/arashi-docs/docs/index.md`
+
+**Checkpoint**: All three user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency checks, quality gates, and release readiness.
+
+- [X] T026 Run install command parity check and resolve mismatches in `repos/arashi/README.md`, `repos/arashi-docs/docs/getting-started/index.md`, and `repos/arashi-docs/docs/index.md`
+- [X] T027 [P] Run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi` and fix resulting issues in touched files
+- [X] T028 [P] Run `bun run validate` and `bun run build` in `repos/arashi-docs` and fix resulting issues in touched files
+- [X] T029 Execute manual acceptance scenarios for curl/npm/hero flows and record outcomes in `repos/arashi-docs/docs/contributing/review-checklist.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies; start immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2.
+- **Phase 4 (US2)**: Depends on Phase 2; can run after US1 MVP validation.
+- **Phase 5 (US3)**: Depends on Phase 2 and should run after US2 content exists for link targets.
+- **Phase 6 (Polish)**: Depends on completion of all targeted stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories; this is MVP scope.
+- **US2 (P2)**: Depends on shared foundations only; should align command text already established by US1.
+- **US3 (P3)**: Depends on US2 install-section anchors/content for final hero links.
+
+### Contract-to-Story Mapping
+
+- `PUT /installation/release-binding` -> US1 (`repos/arashi/scripts/install.sh`, `repos/arashi/.github/workflows/release.yml`, `repos/arashi/.releaserc.json`)
+- `GET|PUT /installation/methods` -> US1 + US2 (`repos/arashi/README.md`, `repos/arashi-docs/docs/getting-started/index.md`)
+- `GET|PUT /installation/surfaces/{surfaceId}/instructions` -> US2 + US3 (`repos/arashi-docs/docs/getting-started/index.md`, `repos/arashi-docs/docs/index.md`)
+- `PUT /installation/access-policy` -> US2 (`repos/arashi-docs/docs/getting-started/index.md`)
+- `POST /installation/consistency-checks` -> Foundational + Polish (`repos/arashi-docs/scripts/check-install-command-parity.ts`)
+- `POST /installation/outcomes` -> Polish manual acceptance recording (`repos/arashi-docs/docs/contributing/review-checklist.md`)
+
+### Data Model to Story Mapping
+
+- **Installation Method** -> US1 (curl), US2 (npm)
+- **Install Script Release Binding** -> US1
+- **Installation Guidance Surface** -> US2 (getting started/readme), US3 (landing hero)
+- **First-Run Outcome** -> Phase 6 validation
+
+---
+
+## Parallel Execution Examples
+
+## Parallel Example: User Story 1
+
+```bash
+# After T012 finalizes installer behavior, these can run in parallel:
+Task: "T013 [US1] Update curl install section in repos/arashi/README.md"
+Task: "T014 [US1] Update curl troubleshooting in repos/arashi/docs/INSTALLATION.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# After T017 defines the npm flow, these can run in parallel:
+Task: "T018 [US2] Add prerequisite/no-account policy in repos/arashi-docs/docs/getting-started/index.md"
+Task: "T019 [US2] Add npm troubleshooting in repos/arashi/docs/INSTALLATION.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# After T023 establishes anchors, styling and terminology alignment can run in parallel:
+Task: "T024 [US3] Update hero install styling in repos/arashi-docs/src/styles/theme.css"
+Task: "T025 [US3] Align hero install wording in repos/arashi-docs/docs/index.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup).
+2. Complete Phase 2 (Foundational).
+3. Complete Phase 3 (US1).
+4. Validate US1 independently using the curl install independent test.
+5. Demo/release MVP if ready.
+
+### Incremental Delivery
+
+1. Deliver US1 (curl path) as MVP.
+2. Deliver US2 (npm parity + fallback) without regressing US1.
+3. Deliver US3 (hero discoverability) once install flows are stable.
+4. Finish with Phase 6 quality gates and consistency validation.
+
+### Parallel Team Strategy
+
+1. One engineer handles installer/release tasks (`repos/arashi/scripts/install.sh`, release config/workflow).
+2. One engineer handles docs onboarding parity (`repos/arashi/README.md`, `repos/arashi-docs/docs/getting-started/index.md`).
+3. One engineer handles landing hero presentation (`repos/arashi-docs/docs/index.md`, `repos/arashi-docs/src/styles/theme.css`).
+
+---
+
+## Notes
+
+- Tasks marked `[P]` are safe parallel opportunities when listed dependencies are met.
+- `[US1]`, `[US2]`, and `[US3]` labels preserve traceability to prioritized stories in `spec.md`.
+- Keep command text identical across README, getting-started, and hero to satisfy FR-006 and SC-003.


### PR DESCRIPTION
## Summary
- add complete feature artifacts for 038-add-install-script, including spec, plan, research, data model, contract, quickstart, and tasks
- record implementation task completion and update agent context with the new install-script workflow details
- provide a ready-to-implement spec package aligned to issue #90 scope