### PR TITLE
specs: add switch command change artifacts

### DIFF
--- a/openspec/changes/implement-switch-command/.openspec.yaml
+++ b/openspec/changes/implement-switch-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-17

--- a/openspec/changes/implement-switch-command/design.md
+++ b/openspec/changes/implement-switch-command/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Arashi currently supports creating, listing, syncing, and removing worktrees, but it does not provide a direct way to jump into an existing worktree from the CLI. Issue #64 requires a `switch` command that can select or filter branch-backed worktrees, then open a new terminal context in that path. The implementation must account for shell limitations (cannot `cd` parent shell), tmux workflows (`--sesh`), and VS Code terminal environments.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `arashi switch` to choose a worktree by branch/path and open it in a new terminal context.
+- Support both filter-first and interactive selection flows.
+- Add `--sesh` behavior for tmux users so switching can use `sesh` when available.
+- Detect VS Code terminal environments and prefer opening a new VS Code window/context.
+- Provide clear fallback behavior and user-facing errors when integrations are unavailable.
+
+**Non-Goals:**
+- Creating or deleting worktrees as part of switch flow.
+- Implementing universal deep integration for every terminal emulator.
+- Changing existing command semantics for `list`, `create`, `add`, `remove`, or `sync`.
+
+## Decisions
+
+### 1) Command shape and selection flow
+- Add a new command module (`src/commands/switch.ts`) and core workflow (`src/core/switch.ts`).
+- Command contract: `arashi switch [filter] [--sesh]` where `filter` is optional and narrows candidates by branch or path.
+- If exactly one candidate matches, switch immediately; if multiple candidates remain and terminal is interactive, prompt user selection.
+- If multiple candidates remain in non-interactive mode, fail with actionable guidance to provide a filter.
+- Alternative considered: requiring interactive prompt every time. Rejected because it is slower for scripted or power-user flows.
+
+### 2) Candidate discovery model
+- Reuse existing worktree discovery primitives (same source of truth used by list/status flows) to avoid divergent branch/path parsing.
+- Normalize each candidate into `{ branchName, worktreePath, repoName }` for display and filtering.
+- Exclude entries that cannot be switched to safely (missing path, invalid metadata), and surface skipped counts in diagnostics.
+- Alternative considered: deriving candidates from directory naming only. Rejected because naming is not authoritative and can drift.
+
+### 3) Terminal target resolution and launch strategy
+- Introduce a small launcher abstraction (`src/lib/switch-launcher.ts`) that resolves target mode from environment and flags.
+- Resolution order:
+  1. `--sesh` + tmux environment (`TMUX`) -> sesh/tmux flow
+  2. VS Code terminal detection (`TERM_PROGRAM=vscode` and related env markers) -> `code --new-window <path>`
+  3. Platform fallback launcher (open a new terminal/tab/window at the worktree path)
+- All process execution uses argument arrays (no shell interpolation) and explicit path escaping where script handoff is required.
+- Alternative considered: forcing one launcher path for all environments. Rejected because tmux and VS Code require distinct integration points.
+
+### 4) `--sesh` behavior contract
+- `--sesh` is opt-in and only changes behavior when running inside tmux.
+- Preflight checks:
+  - Verify tmux context is active.
+  - Verify `sesh` is installed/in `PATH`.
+- On success, open/switch via `sesh` in a new tmux window/pane targeting the selected worktree.
+- On check failure, return a clear error with fallback recommendation (`arashi switch` without `--sesh`).
+- Alternative considered: silently falling back when `sesh` is unavailable. Rejected because silent mode changes are hard to debug.
+
+### 5) Test strategy
+- Unit tests for candidate filtering, environment detection, and launcher resolution precedence.
+- Unit tests for error-path behavior (no matches, ambiguous non-interactive matches, missing `sesh`, missing `code`).
+- Integration tests for command wiring and expected spawn calls via mocked process runner.
+- Do not rely on real terminal automation in tests; validate deterministic command construction and branching.
+
+## Risks / Trade-offs
+
+- [Terminal-specific launch behavior can be brittle] -> Keep launchers narrow, detect capabilities explicitly, and provide deterministic fallback/error messaging.
+- [VS Code CLI may be unavailable even inside VS Code terminal] -> Probe `code` availability before launch and fall back to standard launcher.
+- [sesh invocation details may differ by user setup] -> Encapsulate command construction and keep one adapter surface for future compatibility tweaks.
+- [Filtering may select unintended branch in large workspaces] -> Show branch + path in prompts and require explicit selection when multiple matches remain.
+
+## Migration Plan
+
+1. Add `switch` command registration in `src/index.ts`.
+2. Implement switch core flow and launcher abstraction with environment-aware branching.
+3. Add tests for filtering, launcher resolution, and command-level behavior.
+4. Update CLI docs/help examples with `switch` and `--sesh` usage.
+5. Rollback strategy: remove command registration and switch modules if regressions are found; no config/data migration is required.
+
+## Open Questions
+
+- Confirm the preferred `sesh` invocation shape for worktree paths in tmux sessions.
+- Confirm whether detached-HEAD worktrees should be shown, hidden, or shown with warning labels.
+- Confirm minimum platform support expectations for initial release (macOS-only launcher vs broader Linux/Windows fallbacks).

--- a/openspec/changes/implement-switch-command/proposal.md
+++ b/openspec/changes/implement-switch-command/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Arashi currently has no command for quickly switching into an existing worktree from the CLI, which slows down day-to-day branch navigation in multi-worktree setups. Adding a dedicated switch flow now closes a common workflow gap and aligns with issue #64.
+
+## What Changes
+
+- Add a new `switch` command that lets users select or filter branches that already have associated worktrees.
+- Open a new terminal context at the selected worktree path instead of attempting to `cd` in place.
+- Add a `--sesh` mode that uses `sesh` to switch workspace when the terminal context is tmux.
+- Detect VS Code integrated terminals and prefer opening a new VS Code window/context when supported.
+- Define clear fallback behavior when terminal-specific integration is unavailable.
+
+## Capabilities
+
+### New Capabilities
+- `switch-command`: Interactive and filter-based worktree switching that opens the selected worktree in an appropriate terminal/session context.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: CLI command registration/parsing and a new `switch` command implementation in `repos/arashi`.
+- Affected integrations: terminal launching behavior, tmux/`sesh` detection, and VS Code terminal detection.
+- Affected UX: branch/worktree selection prompts, filtering flow, and user-facing success/error messaging.
+- Affected quality gates: unit/integration tests for switch behavior and terminal-mode branching.

--- a/openspec/changes/implement-switch-command/specs/switch-command/spec.md
+++ b/openspec/changes/implement-switch-command/specs/switch-command/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Discover switchable worktree targets
+The system SHALL discover existing git worktrees associated with the current Arashi workspace and expose each target with its branch reference and absolute worktree path.
+
+#### Scenario: Worktrees are available
+- **WHEN** the user runs `arashi switch`
+- **THEN** the system returns one candidate per discoverable worktree with branch and path metadata
+
+#### Scenario: No worktrees are available
+- **WHEN** the user runs `arashi switch` in a workspace with no switchable worktrees
+- **THEN** the system exits with an error explaining that no switch targets were found
+
+### Requirement: Filter and select a switch target
+The system SHALL support selecting a target by optional filter text and SHALL require explicit disambiguation when multiple candidates remain.
+
+#### Scenario: Filter resolves to a single target
+- **WHEN** the user runs `arashi switch <filter>` and exactly one candidate matches branch or path
+- **THEN** the system selects that candidate without additional prompts
+
+#### Scenario: Multiple matches in interactive terminal
+- **WHEN** the user runs `arashi switch <filter>` in an interactive terminal and multiple candidates match
+- **THEN** the system prompts the user to choose exactly one target
+
+#### Scenario: Multiple matches in non-interactive terminal
+- **WHEN** the user runs `arashi switch <filter>` in a non-interactive terminal and multiple candidates match
+- **THEN** the system exits with an error instructing the user to provide a more specific filter
+
+### Requirement: Open a new terminal context at the selected worktree
+The system SHALL open a new terminal context rooted at the selected worktree path and SHALL NOT attempt to change the working directory of the invoking shell process.
+
+#### Scenario: Successful terminal launch
+- **WHEN** a target is selected and terminal launch succeeds
+- **THEN** the system opens a new terminal context with the selected worktree as the working directory
+
+#### Scenario: Terminal launch fails
+- **WHEN** a target is selected but terminal launch fails
+- **THEN** the system exits with an actionable error that includes the selected path and failure reason
+
+### Requirement: Support tmux sesh mode
+The system SHALL provide a `--sesh` flag that uses sesh-based switching when running in tmux and SHALL validate prerequisites before attempting the switch.
+
+#### Scenario: sesh mode succeeds in tmux
+- **WHEN** the user runs `arashi switch --sesh` inside tmux and `sesh` is available
+- **THEN** the system launches or switches to the selected worktree using sesh integration
+
+#### Scenario: sesh mode requested outside tmux
+- **WHEN** the user runs `arashi switch --sesh` outside tmux
+- **THEN** the system exits with an error explaining that `--sesh` requires tmux
+
+#### Scenario: sesh binary is unavailable
+- **WHEN** the user runs `arashi switch --sesh` in tmux but `sesh` is not found
+- **THEN** the system exits with an error indicating sesh is required and suggesting standard switch mode
+
+### Requirement: Prefer VS Code window switching when in VS Code terminal
+The system SHALL detect VS Code terminal context and SHALL prefer opening a new VS Code window rooted at the selected worktree when VS Code CLI support is available.
+
+#### Scenario: VS Code terminal with CLI available
+- **WHEN** the user runs `arashi switch` from a VS Code terminal and `code` is available
+- **THEN** the system opens a new VS Code window at the selected worktree path
+
+#### Scenario: VS Code terminal without CLI available
+- **WHEN** the user runs `arashi switch` from a VS Code terminal and `code` is unavailable
+- **THEN** the system falls back to standard terminal launch behavior

--- a/openspec/changes/implement-switch-command/tasks.md
+++ b/openspec/changes/implement-switch-command/tasks.md
@@ -1,0 +1,24 @@
+## 1. Command Surface and Data Model
+
+- [x] 1.1 Add `switch` command wiring in `repos/arashi/src/index.ts` and create `repos/arashi/src/commands/switch.ts` with `arashi switch [filter] [--sesh]` options/help text.
+- [x] 1.2 Implement switch command types/errors for no targets, ambiguous non-interactive matches, and launch failures.
+- [x] 1.3 Reuse existing worktree discovery to build normalized switch candidates (`branchName`, `worktreePath`, `repoName`) and skip invalid entries safely.
+
+## 2. Selection and Filtering Flow
+
+- [x] 2.1 Implement filter matching against branch and path and auto-select when exactly one candidate remains.
+- [x] 2.2 Implement interactive selection prompt when multiple matches remain in TTY mode, showing branch + path for each candidate.
+- [x] 2.3 Implement non-interactive ambiguity handling that exits with guidance to provide a more specific filter.
+
+## 3. Launch Integration and Environment Resolution
+
+- [x] 3.1 Add launcher resolution logic that prioritizes `--sesh` in tmux, then VS Code terminal handling, then platform fallback terminal launch.
+- [x] 3.2 Implement `--sesh` preflight checks (tmux context and `sesh` availability) and sesh/tmux invocation for selected worktree.
+- [x] 3.3 Implement VS Code terminal detection and `code --new-window <path>` launch with fallback when `code` is unavailable.
+- [x] 3.4 Implement fallback terminal launch path and ensure all spawns use argument arrays with actionable errors on failure.
+
+## 4. Verification and Documentation
+
+- [x] 4.1 Add unit tests for filtering/selection behavior, environment resolution precedence, and error branches.
+- [x] 4.2 Add integration tests for command wiring and expected process-runner invocations for sesh, VS Code, and fallback launch modes.
+- [x] 4.3 Update CLI docs/help examples for `arashi switch` and `--sesh`, then run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi`.


### PR DESCRIPTION
## Summary
- add OpenSpec change artifacts for `implement-switch-command` (proposal, design, tasks, and delta spec)
- capture switch command goals, terminal integration decisions, and implementation task breakdown
- mark implementation tasks complete for the delivered feature

## Related
- Companion implementation PR: https://github.com/corwinm/arashi/pull/36
- Companion docs PR: https://github.com/corwinm/arashi-docs/pull/6
- Companion skills PR: https://github.com/corwinm/arashi-skills/pull/5
- Related issue: https://github.com/corwinm/arashi/issues/64