### PR TITLE
specs: add remove hook artifacts and ship workflow

### DIFF
--- a/.agents/skills/arashi/SKILL.md
+++ b/.agents/skills/arashi/SKILL.md
@@ -36,6 +36,7 @@ Use this skill when the user wants to:
 - choose a workflow by difficulty (beginner, intermediate, advanced)
 - validate readiness before running commands across multiple repositories
 - speed up daily navigation with `fzf`, `tmux`, and `sesh`
+- automate cleanup around `arashi remove` with lifecycle hooks
 - recover from setup, network, or command failures without guesswork
 
 ## Core Commands
@@ -56,6 +57,7 @@ When guiding a user, always:
 2. Confirm `arashi --version` before running workflows.
 3. Confirm expected outcomes after each workflow step.
 4. Route failures through the troubleshooting matrix before retrying.
+5. For remove cleanup automation, use `pre-remove.sh` and `post-remove.sh` templates in `.arashi/hooks/`.
 
 ## Workflow Catalog
 

--- a/.agents/skills/arashi/assets/cheatsheet.md
+++ b/.agents/skills/arashi/assets/cheatsheet.md
@@ -20,6 +20,17 @@ arashi pull
 arashi sync
 ```
 
+## Remove Hook Setup
+
+```bash
+cp .arashi/hooks/pre-remove.sh.example .arashi/hooks/pre-remove.sh
+chmod +x .arashi/hooks/pre-remove.sh
+
+# optional post-remove cleanup
+cp .arashi/hooks/post-remove.sh.example .arashi/hooks/post-remove.sh
+chmod +x .arashi/hooks/post-remove.sh
+```
+
 ## tmux / sesh Shortcuts (Optional)
 
 ```bash

--- a/.agents/skills/arashi/references/commands.md
+++ b/.agents/skills/arashi/references/commands.md
@@ -46,6 +46,22 @@ Order of operations:
 2. Execute one workflow from start to finish.
 3. Confirm expected outcomes from the workflow doc.
 
+## Remove Cleanup Hooks
+
+Use remove lifecycle hooks to automate teardown around `arashi remove`.
+
+```bash
+cp .arashi/hooks/pre-remove.sh.example .arashi/hooks/pre-remove.sh
+chmod +x .arashi/hooks/pre-remove.sh
+
+# optional post-remove finalizer
+cp .arashi/hooks/post-remove.sh.example .arashi/hooks/post-remove.sh
+chmod +x .arashi/hooks/post-remove.sh
+```
+
+`pre-remove.sh` runs before destructive remove actions.
+`post-remove.sh` runs after remove actions are attempted.
+
 ## Session Navigation (Optional)
 
 For tmux/sesh and worktree jump shortcuts, use:

--- a/.agents/skills/arashi/references/tutorial.md
+++ b/.agents/skills/arashi/references/tutorial.md
@@ -62,7 +62,20 @@ sesh connect "$(arashi list | fzf)"
 
 Use this step only when `fzf` and `sesh` are installed.
 
-## Step 6: Simulate and Recover
+## Step 6: Optional Remove Hook Setup
+
+```bash
+cp .arashi/hooks/pre-remove.sh.example .arashi/hooks/pre-remove.sh
+chmod +x .arashi/hooks/pre-remove.sh
+
+# optional final cleanup hook
+cp .arashi/hooks/post-remove.sh.example .arashi/hooks/post-remove.sh
+chmod +x .arashi/hooks/post-remove.sh
+```
+
+Use these hooks to automate teardown tasks (for example tmux session cleanup) around `arashi remove`.
+
+## Step 7: Simulate and Recover
 
 If `arashi` is not on `PATH`, run:
 

--- a/.agents/skills/arashi/references/workflows.md
+++ b/.agents/skills/arashi/references/workflows.md
@@ -19,6 +19,7 @@ Use this catalog to choose the right workflow by goal and confidence level.
 - Start with **Beginner** if this is your first Arashi skill session.
 - Choose **Intermediate** if you already have repositories and need cross-repo branch creation.
 - Choose **Advanced** if you need sync and recovery controls.
+- If you automate teardown on branch removal, set up `pre-remove.sh` / `post-remove.sh` from the hook templates.
 - If you use tmux/sesh, apply shortcuts from `references/session-shortcuts.md`.
 
 ## Workflow Entry Commands

--- a/.arashi/hooks/pre-remove.sh
+++ b/.arashi/hooks/pre-remove.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Pre-Remove Hook Example
+#
+# This hook runs BEFORE remove operations start.
+# Use it to stop related services/sessions or validate removal preconditions.
+#
+# Environment variables:
+#   ARASHI_HOOK_NAME                  - Hook name (`pre-remove`)
+#   ARASHI_MAIN_REPO_PATH             - Workspace root path
+#   ARASHI_BRANCH_NAME                - Primary target branch (if available)
+#   ARASHI_WORKTREE_PATH              - Primary target worktree path (if available)
+#   ARASHI_REMOVE_TARGET_BRANCHES     - Comma-separated target branches
+#   ARASHI_REMOVE_TARGET_WORKTREES    - Comma-separated target worktree paths
+#   ARASHI_REMOVE_TARGET_REPOSITORIES - Comma-separated target repositories
+#
+# Exit codes:
+#   0 - Success, continue removal
+#   Non-zero - Abort remove command before destructive operations
+
+set -e
+
+echo "Pre-remove hook: preparing to remove worktrees"
+
+# Example: stop a tmux session tied to branch name
+if [ -n "$ARASHI_BRANCH_NAME" ] && command -v tmux >/dev/null 2>&1; then
+  tmux has-session -t "$ARASHI_BRANCH_NAME" 2>/dev/null \
+    && tmux kill-session -t "$ARASHI_BRANCH_NAME" \
+    || true
+fi
+
+exit 0

--- a/.opencode/command/ship.md
+++ b/.opencode/command/ship.md
@@ -1,0 +1,129 @@
+---
+description: Create coordinated multi-repo commits and optional PRs
+---
+
+Create coordinated commits across the parent specs repo and every changed child repo, then optionally open linked PRs.
+
+**Input**: Optionally specify an issue URL/number or change name after `/ship`.
+
+Examples:
+- `/ship`
+- `/ship https://github.com/corwinm/arashi-arashi/issues/123`
+- `/ship #123`
+
+**Goal**
+
+- Commit all relevant changes in all affected repositories.
+- Reference the original spec issue in every commit.
+- Ask whether to open PRs.
+- If yes, create PRs for each affected repository with cross-links.
+- Ensure the parent specs PR closes the related issue.
+
+**Steps**
+
+1. **Detect affected repositories**
+
+   - Treat the current workspace root as the **parent specs repo**.
+   - Discover child repos under `repos/*` that are git repositories.
+   - For each repository (parent + children), run `git status --short`.
+   - Keep only repositories with changes.
+   - If no repositories have changes, report and stop.
+
+2. **Resolve the canonical issue reference**
+
+   Prefer in this order:
+
+   1) Argument passed to `/ship` if it is an issue URL/number
+   2) Parse modified `specs/*/spec.md` files for an issue URL (`https://github.com/.../issues/<n>`)
+   3) Parse changed OpenSpec artifacts (`openspec/changes/*`) for a linked issue URL
+
+   If still missing or ambiguous, use **AskUserQuestion** to request the canonical issue URL.
+
+   Also derive:
+   - `issueUrl` (full URL)
+   - `issueNumber` (numeric, when available)
+   - `issueRefShort` (`owner/repo#number` when available)
+
+3. **Commit each changed repository (one commit per repo)**
+
+   For each changed repo, in sequence:
+
+   - Run `git status`, `git diff`, and recent `git log` to align with local commit style.
+   - Stage relevant tracked/untracked files.
+   - Exclude likely secret files (`.env`, `*.pem`, credentials files).
+   - Draft a focused commit message (why-oriented) and include issue reference.
+
+   Commit message guidance:
+   - Parent specs repo: include issue reference in body (for example `Refs: <issueUrl>`).
+   - Child repos: include same issue reference in body.
+
+   Quality checks before each commit:
+   - Run project-required checks when available.
+   - For `repos/arashi`, run:
+     - `bun run lint`
+     - `bun test`
+     - `bun run build`
+   - Fix failures before committing.
+
+4. **Prompt to create PRs**
+
+   Use **AskUserQuestion**:
+   - "Create PRs for all committed repositories now?"
+   - options: `Yes` / `No`
+
+   If `No`, stop after reporting committed repos and branches.
+
+5. **If Yes, create PRs for each committed repository**
+
+   For each committed repo:
+
+   - Verify current branch and remote tracking.
+   - Push with upstream if needed: `git push -u origin <branch>`.
+   - Create PR with `gh pr create` (title/body based on repo changes).
+   - Capture every PR URL.
+
+6. **Backfill cross-references in every PR body**
+
+   After all PRs exist, update each PR body so links are bidirectional.
+
+   Required body section in every PR:
+
+   ```markdown
+   ## Related
+   - Companion implementation/spec PRs: <all other PR URLs>
+   - Related issue: <issueUrl>
+   ```
+
+   Additional rule for parent specs PR:
+   - Include a closing keyword for the issue (`Closes #<issueNumber>` when valid in that repo; otherwise `Closes <issueUrl>`).
+
+   Additional rule for non-parent PRs:
+   - Do **not** close the issue.
+   - Include issue as reference only.
+
+7. **Report final results**
+
+   Show:
+   - issue used (`issueUrl`)
+   - committed repositories with commit SHAs
+   - PR URL per repository (if created)
+   - confirmation that parent PR closes the issue
+
+**Output**
+
+At minimum:
+
+- Parent specs repo commit status
+- Child repo commit status
+- PR decision (`Yes`/`No`)
+- PR URLs (if created)
+- Cross-link/issue linkage confirmation
+
+**Guardrails**
+
+- One commit per changed repository (no cross-repo commit attempts).
+- Do not commit unchanged repositories.
+- Do not amend commits unless explicitly requested.
+- Never use destructive git operations (`reset --hard`, force-push) unless explicitly requested.
+- Do not skip hooks unless explicitly requested.
+- Ask before proceeding only when issue resolution is ambiguous or missing.

--- a/openspec/changes/add-pre-remove-and-post-remove-hooks/.openspec.yaml
+++ b/openspec/changes/add-pre-remove-and-post-remove-hooks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-18

--- a/openspec/changes/add-pre-remove-and-post-remove-hooks/design.md
+++ b/openspec/changes/add-pre-remove-and-post-remove-hooks/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The remove flow currently performs discovery, confirmation, worktree removal, and branch deletion, but it has no lifecycle hook points. Teams that rely on external session/state cleanup (for example tmux sessions tied to branch/worktree paths) must do that work manually after `arashi remove`, which is error-prone and easy to forget.
+
+Existing hook infrastructure already supports named lifecycle scripts under `.arashi/hooks/` with timeout handling, structured outcomes, and user-visible logging. This change extends that model to remove operations without changing remove target resolution semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `pre-remove` and `post-remove` lifecycle hooks to the remove command.
+- Define deterministic execution order relative to confirmation, worktree removal, and branch deletion.
+- Provide clear behavior when hooks fail (abort vs continue), including exit status and user-visible errors.
+- Reuse existing hook execution primitives so timeout, validation, and output behavior remain consistent.
+
+**Non-Goals:**
+- Redesigning remove target selection, grouping, or prompt UX.
+- Introducing a new hook configuration format beyond existing `.arashi/hooks/<hook-name>.sh` discovery.
+- Adding persistent hook execution logs beyond current command output.
+
+## Decisions
+
+### 1) Lifecycle model and script names
+- Add two global remove lifecycle names: `pre-remove` and `post-remove`.
+- Discover scripts via existing convention: `.arashi/hooks/pre-remove.sh` and `.arashi/hooks/post-remove.sh` in the workspace root repository.
+- Keep this first iteration global-only for remove lifecycle hooks; per-repository remove hook names are deferred.
+- Alternative considered: also introduce `pre-remove.<repo>` / `post-remove.<repo>` now. Rejected to keep initial behavior predictable and avoid multiplying invocation counts during multi-repository removal.
+
+### 2) Remove pipeline integration and ordering
+- Integrate hook execution into `executeRemove` in `repos/arashi/src/commands/remove.ts`.
+- Execution order:
+  1. Resolve targets, check dirty state, and gather final operation plan.
+  2. Prompt confirmation (when not forced).
+  3. Run `pre-remove` once.
+  4. Execute worktree removals and branch deletions.
+  5. Run `post-remove` once.
+  6. Print final summary.
+- `pre-remove` runs after confirmation so cancelled operations do not trigger cleanup hooks.
+- Alternative considered: run `pre-remove` before confirmation to allow preflight gating. Rejected because it runs side effects even when user declines.
+
+### 3) Hook context payload for remove lifecycle
+- Reuse existing hook execution plumbing and operation data builder in `repos/arashi/src/lib/hooks.ts`.
+- Extend operation data for remove to include branch/repository/worktree context that hooks need for teardown logic.
+- For multi-target removals, include aggregate context (counts and primary target metadata) and per-operation metadata when available.
+- Keep environment contract backward-compatible by using existing `ARASHI_*` prefixed variables.
+- Alternative considered: introduce a new JSON payload file contract. Rejected to avoid extra IO complexity for a first version.
+
+### 4) Failure semantics and exit behavior
+- If `pre-remove` fails (non-zero or timeout), abort all remove actions and return non-zero.
+- If remove actions produce partial failures, still attempt `post-remove` to allow best-effort cleanup/finalization.
+- If `post-remove` fails, include it in summary errors and return non-zero.
+- If hooks are missing, mark as skipped and continue (same semantics as existing hook system).
+- Alternative considered: skip `post-remove` whenever any remove action fails. Rejected because cleanup is often most important in failure scenarios.
+
+### 5) Test strategy
+- Add command-level tests that verify lifecycle ordering (`pre-remove` before remove ops, `post-remove` after).
+- Add failure-path tests:
+  - `pre-remove` failure aborts remove and no worktree/branch operations execute.
+  - Remove operation failure still allows `post-remove` execution.
+  - `post-remove` failure marks command unsuccessful.
+  - Missing hooks are reported as skipped without failing command.
+- Add integration coverage for a cleanup-style hook scenario (for example simulated session cleanup side effect).
+- Alternative considered: rely only on unit tests in hook library. Rejected because orchestration ordering is owned by remove command flow.
+
+## Risks / Trade-offs
+
+- [Cleanup hook can accidentally remove unrelated resources] -> Keep hook scope explicit with clear environment variables and document safe guard clauses.
+- [Post-remove hook failure may mask underlying remove errors] -> Aggregate and print both operation and hook errors in summary output.
+- [Hook runtime can slow remove operations] -> Reuse existing timeout configuration and emit duration in hook outcomes.
+- [Global-only hooks may be insufficient for some teams] -> Document as v1 and leave room for repo-specific remove hooks in a follow-up capability.
+
+## Migration Plan
+
+1. Add remove lifecycle constants and shared helper wiring in hook utilities.
+2. Add remove command orchestration calls for `pre-remove` and `post-remove` with defined ordering.
+3. Extend remove summary/error aggregation to include hook failures and skipped states.
+4. Add tests for ordering, missing-hook behavior, and failure semantics.
+5. Update user docs/examples to include `pre-remove.sh` and `post-remove.sh` usage for cleanup workflows.
+
+Rollback strategy: revert lifecycle integration in remove command and constants; no config schema migration is required.
+
+## Open Questions
+
+- Should remove hooks receive a structured list of all selected targets (for example JSON string) in addition to scalar env vars?
+- Do we want to add repo-specific remove lifecycle hooks in a follow-up once global behavior is stable?

--- a/openspec/changes/add-pre-remove-and-post-remove-hooks/proposal.md
+++ b/openspec/changes/add-pre-remove-and-post-remove-hooks/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Arashi currently supports setup/create-time hook flows, but remove operations do not expose lifecycle hooks for cleanup. Adding `pre-remove` and `post-remove` hooks now enables reliable teardown workflows (for example, tmux session cleanup) when worktrees are removed.
+
+## What Changes
+
+- Add `pre-remove` and `post-remove` hook phases to the remove workflow.
+- Define execution order and behavior for both successful and failed remove operations.
+- Extend hook discovery/configuration so remove hooks can be registered alongside existing hook scripts.
+- Surface clear CLI output for remove hook execution, including failures and skipped hooks.
+- Add tests for remove hook invocation timing, error handling, and no-hook behavior.
+
+## Capabilities
+
+### New Capabilities
+- `remove-lifecycle-hooks`: Hook lifecycle support around worktree removal, including pre-remove and post-remove execution contracts.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: remove command orchestration, hook execution utilities, and workspace hook configuration handling in `repos/arashi`.
+- Affected behavior: remove operations now expose lifecycle extension points for cleanup automation.
+- Affected UX: users receive explicit feedback when remove hooks run, fail, or are not configured.
+- Affected quality gates: unit/integration tests covering remove hook sequencing and failure semantics.

--- a/openspec/changes/add-pre-remove-and-post-remove-hooks/specs/remove-lifecycle-hooks/spec.md
+++ b/openspec/changes/add-pre-remove-and-post-remove-hooks/specs/remove-lifecycle-hooks/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Remove command lifecycle hooks
+The system SHALL support global remove lifecycle hooks named `pre-remove` and `post-remove` that are discovered from `.arashi/hooks/<hook-name>.sh` in the workspace root repository.
+
+#### Scenario: Remove hooks are configured
+- **WHEN** a user runs `arashi remove` in a workspace where `.arashi/hooks/pre-remove.sh` and `.arashi/hooks/post-remove.sh` exist
+- **THEN** the command evaluates and executes those hooks at their defined lifecycle points
+
+#### Scenario: Remove hooks are not configured
+- **WHEN** a user runs `arashi remove` and one or both remove hook files are absent
+- **THEN** the command skips missing hooks without failing solely because the scripts are absent
+
+### Requirement: Pre-remove hook gates destructive operations
+The system SHALL execute `pre-remove` after user confirmation and before any worktree removal or branch deletion, and the command MUST abort destructive operations when `pre-remove` fails.
+
+#### Scenario: Pre-remove succeeds
+- **WHEN** `pre-remove` exits successfully
+- **THEN** the command proceeds to worktree removal and branch deletion
+
+#### Scenario: Pre-remove fails
+- **WHEN** `pre-remove` exits non-zero or times out
+- **THEN** the command exits with failure and does not remove worktrees or delete branches
+
+### Requirement: Post-remove hook finalization behavior
+The system SHALL execute `post-remove` once after remove operations have been attempted, including runs where some remove operations fail.
+
+#### Scenario: Remove operations fully succeed
+- **WHEN** all targeted remove operations complete successfully
+- **THEN** `post-remove` runs after those operations and before final completion output
+
+#### Scenario: Remove operations partially fail
+- **WHEN** one or more targeted remove operations fail but the command continues processing remaining targets
+- **THEN** `post-remove` still runs once after operation attempts complete
+
+### Requirement: Remove lifecycle hook context
+The system SHALL provide remove lifecycle hooks with `ARASHI_*` environment variables sufficient to identify the remove operation context, including target branch and/or worktree metadata when available.
+
+#### Scenario: Hook receives remove context
+- **WHEN** a remove lifecycle hook runs
+- **THEN** the hook process receives populated `ARASHI_*` variables that allow cleanup logic to identify the relevant operation scope
+
+### Requirement: Hook failures affect command result
+The system MUST treat remove lifecycle hook failures as command errors and SHALL report hook failure details in user-visible output.
+
+#### Scenario: Post-remove fails
+- **WHEN** `post-remove` exits non-zero or times out
+- **THEN** the command reports the hook failure and returns a non-zero exit status

--- a/openspec/changes/add-pre-remove-and-post-remove-hooks/tasks.md
+++ b/openspec/changes/add-pre-remove-and-post-remove-hooks/tasks.md
@@ -1,0 +1,26 @@
+## 1. Extend hook primitives for remove lifecycle
+
+- [x] 1.1 Add `pre-remove` and `post-remove` lifecycle constants in `repos/arashi/src/lib/hooks.ts`
+- [x] 1.2 Add/remove-lifecycle helper(s) to build `ARASHI_*` operation context for remove hooks
+- [x] 1.3 Ensure remove lifecycle hook discovery uses existing `.arashi/hooks/<hook-name>.sh` behavior and skipped outcomes for missing scripts
+
+## 2. Integrate remove hooks into command orchestration
+
+- [x] 2.1 Wire `pre-remove` execution into `executeRemove` after confirmation and before destructive operations
+- [x] 2.2 Enforce abort semantics when `pre-remove` fails (non-zero or timeout)
+- [x] 2.3 Wire `post-remove` execution after remove operations complete, including partial-failure runs
+- [x] 2.4 Aggregate hook outcomes into remove summary/error handling so hook failures produce non-zero exit status with actionable output
+
+## 3. Add test coverage for lifecycle behavior
+
+- [x] 3.1 Add tests that verify remove lifecycle ordering (`pre-remove` -> remove operations -> `post-remove`)
+- [x] 3.2 Add tests that verify `pre-remove` failure prevents worktree removal and branch deletion
+- [x] 3.3 Add tests that verify `post-remove` still executes when some remove operations fail
+- [x] 3.4 Add tests for missing-hook skip behavior and post-remove failure exit status
+
+## 4. Update examples and validation workflow
+
+- [x] 4.1 Add or update hook template/docs to include `pre-remove.sh` and `post-remove.sh` usage for cleanup workflows
+- [x] 4.2 Run `bun run lint` in `repos/arashi` and fix any issues
+- [x] 4.3 Run `bun test` in `repos/arashi` and address failing tests
+- [x] 4.4 Run `bun run build` in `repos/arashi` to verify distribution build succeeds


### PR DESCRIPTION
## Summary
- Add OpenSpec change artifacts for pre-remove and post-remove lifecycle hooks.
- Add a `/ship` slash command to coordinate multi-repo commits and optional cross-linked PRs.
- Update local Arashi skill mirror references with remove-hook setup guidance.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/37, https://github.com/corwinm/arashi-skills/pull/6
- Related issue: https://github.com/corwinm/arashi-arashi/issues/83

Closes #83