### PR TITLE
Add OpenSpec artifacts for VS Code extension integration

### DIFF
--- a/openspec/changes/create-vscode-plugin/.openspec.yaml
+++ b/openspec/changes/create-vscode-plugin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-18

--- a/openspec/changes/create-vscode-plugin/design.md
+++ b/openspec/changes/create-vscode-plugin/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Arashi is currently consumed through a terminal-first CLI, but issue #59 asks for a VS Code-native experience so developers can run common operations and manage worktrees without leaving the editor. The proposal introduces two capabilities: command integration and a worktree panel. The design must preserve existing CLI behavior, use native VS Code interaction patterns, and provide clear feedback when command execution fails.
+
+Key constraints:
+- Implementation lives in `repos/arashi-vscode`.
+- The extension should reuse existing Arashi CLI functionality rather than reimplementing git/worktree logic.
+- Inputs and confirmations should use native VS Code UI components.
+- Worktree state should be visible and actionable from a single panel.
+- Minimum extension engine should match `oil.code`: `^1.96.2`.
+- The extension should remain compatible with Cursor and other VS Code forks that support standard VS Code extension APIs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide VS Code commands for core Arashi flows (`init`, `add`, `create`, `switch`, `remove`) with keybinding compatibility.
+- Provide a worktree explorer panel with status indicators and contextual actions (switch, remove, add repo).
+- Standardize command execution, logging, and error reporting in extension code.
+- Keep extension architecture maintainable and aligned with conventions from the referenced `oil.code` extension.
+
+**Non-Goals:**
+- Reimplement Arashi internals (git/worktree orchestration) inside the extension.
+- Replace terminal usage for advanced or niche flags not represented in initial command UX.
+- Introduce remote orchestration, cloud services, or non-VS Code editor integrations.
+
+## Decisions
+
+### 1) CLI-backed extension architecture
+
+Decision: Execute Arashi operations by invoking the existing CLI from extension command handlers.
+
+Rationale:
+- Keeps one source of truth for behavior and validation.
+- Reduces duplicated business logic and drift risk.
+- Allows extension iterations to focus on editor UX.
+
+Alternatives considered:
+- Rebuild worktree logic directly in extension TypeScript: rejected due to high duplication and maintenance burden.
+- Add a background daemon/API for editor integration first: rejected for initial scope because it adds new deployment/runtime complexity.
+
+### 2) Central command runner and input adapters
+
+Decision: Implement a shared command runner module that handles argument building, process execution, output capture, cancellation/timeout, and standardized error mapping. Each VS Code command uses this runner plus UI adapters (`QuickPick`, `InputBox`, modal confirmation prompts). Any command whose output is parsed by the extension must request machine-readable output via `--json`.
+
+Rationale:
+- Produces consistent UX across commands.
+- Simplifies testability and future command additions.
+- Enables clear user feedback through VS Code notifications and an output channel.
+
+Alternatives considered:
+- Independent per-command execution code: rejected due to duplicated error handling and inconsistent UX.
+
+### 3) Compatibility-first API and engine target
+
+Decision: Target the same minimum VS Code engine used by `oil.code` (`^1.96.2`) and restrict implementation to stable VS Code APIs to support Cursor and other VS Code forks.
+
+Rationale:
+- Aligns with the maintainer's proven extension baseline.
+- Maximizes compatibility across VS Code-based editors.
+- Avoids vendor-specific coupling that could break in forks.
+
+Alternatives considered:
+- Target newer engine and newer APIs: rejected for initial release due to reduced fork compatibility.
+- Use proposed/experimental APIs: rejected because fork support is less predictable.
+
+### 4) Worktree panel via `TreeDataProvider`
+
+Decision: Build an Arashi worktree view using `TreeDataProvider`, backed by parsed CLI status/list output, with explicit refresh and post-command refresh hooks.
+
+Rationale:
+- Uses standard VS Code view APIs for hierarchy, actions, and context menus.
+- Keeps panel state derived from authoritative CLI output.
+- Supports incremental enhancement (badges, filters, repo grouping) without architectural change.
+
+Alternatives considered:
+- Custom webview panel: rejected because native tree views provide better integration and lower complexity for this use case.
+- File-system-only discovery: rejected because Arashi metadata and status should remain CLI-derived.
+
+### 5) Initial command and panel rollout strategy
+
+Decision: Deliver commands and panel actions in phases, starting with the core command set and read-optimized panel, then adding mutating panel actions once reliability is validated. For panel mutations, require confirmation only for destructive operations (for example, remove/delete), while non-destructive actions (for example, switch) execute directly. Publish the extension to both VS Marketplace and Open VSX in the initial rollout.
+
+Rationale:
+- Reduces release risk for first extension version.
+- Allows quick feedback on command UX before expanding surface area.
+- Improves discoverability and installability across VS Code and VS Code forks.
+
+Alternatives considered:
+- Ship all actions and advanced configuration at once: rejected due to larger testing matrix and slower feedback loop.
+
+## Risks / Trade-offs
+
+- [CLI path/environment mismatch] -> Mitigation: add configurable binary path and workspace-root settings, plus startup validation with actionable errors.
+- [Long-running commands can feel unresponsive] -> Mitigation: show progress notifications/spinners and stream output to a dedicated output channel.
+- [CLI output format changes can break parsing] -> Mitigation: prefer machine-readable output modes where available and isolate parsers behind typed adapters.
+- [Panel state can become stale] -> Mitigation: refresh after each command, expose manual refresh action, and debounce periodic refresh.
+- [Cross-platform process execution differences] -> Mitigation: test on macOS/Linux/Windows shells and avoid shell-specific command composition.
+- [Behavior differences across VS Code forks] -> Mitigation: stay on stable APIs, test in VS Code and Cursor, and degrade gracefully when optional features are unavailable.
+- [Marketplace publishing drift across channels] -> Mitigation: automate release metadata checks and publish steps for VS Marketplace and Open VSX from the same tagged pipeline.
+
+## Migration Plan
+
+1. Scaffold extension project in `repos/arashi-vscode` with baseline configuration (commands, view contributions, activation events, packaging, `engines.vscode: ^1.96.2`).
+2. Implement command runner + UX adapters and wire core commands.
+3. Implement command JSON integration paths by adding `--json` to CLI calls that are parsed by extension logic.
+4. Implement worktree `TreeDataProvider` with read-only visualization and refresh.
+5. Add contextual panel actions (switch/remove/add repo) using the same runner pipeline, with confirmation only for destructive actions.
+6. Validate compatibility on VS Code and Cursor.
+7. Add automated tests (runner behavior, parser coverage, command registration) and manual end-to-end validation against real Arashi workspaces.
+8. Publish preview release to VS Marketplace and Open VSX, gather feedback, then harden based on observed failures.
+
+Rollback strategy:
+- Disable extension commands/views by reverting extension package release; no migration of repository data is required because source of truth remains Arashi CLI + local git metadata.
+
+## Open Questions
+
+- Which CLI subcommands already provide stable JSON output suitable for parsing, and where do wrappers need to be introduced?

--- a/openspec/changes/create-vscode-plugin/proposal.md
+++ b/openspec/changes/create-vscode-plugin/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Arashi is currently easiest to use from the terminal, which makes common workflows slower for developers who work primarily inside VS Code. Issue #59 requests a first-class editor integration so users can trigger Arashi actions with native VS Code prompts and manage worktrees without leaving the IDE.
+
+## What Changes
+
+- Create a VS Code extension that contributes keybind-friendly commands for core Arashi actions (`init`, `add`, `create`, `switch`, `remove`) and gathers input with native VS Code UI.
+- Add a dedicated worktree panel that lists Arashi-managed worktrees, shows git-change status, and supports quick actions (switch, delete, add repo).
+- Add extension-side command execution, result reporting, and error handling so command success/failure is clear in the VS Code experience.
+- Ensure extension command integrations use machine-readable CLI output (`--json`) for operations that require parsing.
+- Add extension configuration, packaging, and project scaffolding aligned with existing extension conventions referenced in issue #59.
+
+## Capabilities
+
+### New Capabilities
+
+- `vscode-command-integration`: Expose Arashi CLI operations as VS Code commands with native input/confirmation flows and keybinding support.
+- `vscode-worktree-panel`: Provide a VS Code view that displays Arashi worktrees with status indicators and contextual management actions.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds a new VS Code extension implementation area under `repos/arashi-vscode`, including command handlers and view-provider logic.
+- Introduces dependency on the VS Code extension runtime and extension packaging/release configuration.
+- Requires release/publishing support for both VS Marketplace and Open VSX.
+- Expands documentation and onboarding for editor-based workflows while keeping existing CLI behavior intact, with compatibility expectations for VS Code forks such as Cursor.

--- a/openspec/changes/create-vscode-plugin/specs/vscode-command-integration/spec.md
+++ b/openspec/changes/create-vscode-plugin/specs/vscode-command-integration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Register core Arashi commands in VS Code
+The extension SHALL register VS Code commands for `arashi init`, `arashi add`, `arashi create`, `arashi switch`, and `arashi remove`, and SHALL make them available for command-palette use and keybinding assignment.
+
+#### Scenario: Core commands are discoverable
+- **WHEN** the extension activates in a supported editor
+- **THEN** each core Arashi command appears in the command palette and can be bound to a keybinding
+
+### Requirement: Use native VS Code input and confirmation flows
+The extension SHALL gather required command inputs and confirmations through native VS Code UI components before invoking Arashi.
+
+#### Scenario: Command requires user input
+- **WHEN** a command is triggered without required arguments
+- **THEN** the extension prompts with native VS Code input or selection UI and passes the collected values to the CLI invocation
+
+#### Scenario: User cancels input flow
+- **WHEN** a user dismisses an input or selection prompt
+- **THEN** the extension cancels command execution and reports a non-error cancellation message
+
+### Requirement: Request machine-readable CLI output for parsed flows
+The extension SHALL pass `--json` to Arashi CLI commands whenever the extension parses command output for UI state, decision-making, or validation.
+
+#### Scenario: Parsed command succeeds
+- **WHEN** the extension runs a command whose output is consumed by extension logic
+- **THEN** the CLI invocation includes `--json` and the extension parses structured output instead of terminal text
+
+#### Scenario: Parsed command returns invalid JSON
+- **WHEN** a `--json` command returns malformed or unsupported output
+- **THEN** the extension shows an actionable error and records diagnostic details in the extension output channel
+
+### Requirement: Provide consistent execution feedback
+The extension SHALL present command success and failure outcomes through standardized notifications and an output channel entry containing command context.
+
+#### Scenario: Command succeeds
+- **WHEN** an Arashi command exits successfully
+- **THEN** the extension shows a success notification and logs the executed command context in the output channel
+
+#### Scenario: Command fails
+- **WHEN** an Arashi command exits with an error
+- **THEN** the extension shows an error notification with remediation guidance and logs stderr details in the output channel
+
+### Requirement: Preserve compatibility across VS Code forks
+The extension SHALL declare `engines.vscode` as `^1.96.2` and SHALL use stable VS Code APIs so it can run in VS Code and compatible forks such as Cursor.
+
+#### Scenario: Compatible editor runs extension
+- **WHEN** the extension is installed in VS Code or a compatible fork that satisfies `^1.96.2`
+- **THEN** command registration and execution behavior matches the documented baseline
+
+### Requirement: Publish releases to both extension marketplaces
+The release process SHALL publish each production extension version to both VS Marketplace and Open VSX.
+
+#### Scenario: Production release is published
+- **WHEN** a new production extension version is released
+- **THEN** that version is available in both VS Marketplace and Open VSX

--- a/openspec/changes/create-vscode-plugin/specs/vscode-worktree-panel/spec.md
+++ b/openspec/changes/create-vscode-plugin/specs/vscode-worktree-panel/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Display Arashi worktrees with status metadata
+The extension SHALL provide a worktree panel that lists Arashi-managed worktrees with repository context, branch identity, path, and git-change status indicators.
+
+#### Scenario: Worktrees are available
+- **WHEN** the worktree panel is opened in a configured workspace
+- **THEN** the panel displays one entry per discovered Arashi worktree with branch, path, and status metadata
+
+#### Scenario: No worktrees are available
+- **WHEN** the worktree panel is opened and no Arashi worktrees are discovered
+- **THEN** the panel shows an explicit empty state with guidance for creating or adding a worktree
+
+### Requirement: Back panel data with JSON CLI responses
+The worktree panel SHALL source its data from Arashi CLI commands invoked with `--json` when output is parsed by the extension.
+
+#### Scenario: Panel refresh succeeds
+- **WHEN** the panel performs discovery or refresh
+- **THEN** the extension invokes CLI data commands with `--json` and renders the parsed response
+
+#### Scenario: Panel refresh parse fails
+- **WHEN** JSON parsing fails during panel refresh
+- **THEN** the extension preserves the last known panel state when available and shows an actionable refresh error
+
+### Requirement: Provide contextual worktree actions
+The worktree panel SHALL provide contextual actions to switch to a worktree, remove a worktree, and add a repository.
+
+#### Scenario: Switch action from panel
+- **WHEN** a user triggers switch on a selected worktree entry
+- **THEN** the extension executes the switch flow for that target and reports the outcome
+
+#### Scenario: Add repository action from panel
+- **WHEN** a user triggers add repository from the panel
+- **THEN** the extension launches the add flow with native VS Code input UI and updates the panel after completion
+
+### Requirement: Confirm destructive panel operations only
+The extension MUST require explicit confirmation for destructive panel actions and SHALL NOT require confirmation for non-destructive actions.
+
+#### Scenario: Remove worktree requires confirmation
+- **WHEN** a user triggers remove on a worktree
+- **THEN** the extension requires explicit confirmation before invoking removal
+
+#### Scenario: Switch does not require confirmation
+- **WHEN** a user triggers switch on a worktree
+- **THEN** the extension executes the action without a confirmation prompt
+
+### Requirement: Keep panel state synchronized after actions
+The worktree panel SHALL refresh after mutating actions and SHALL provide a manual refresh command.
+
+#### Scenario: State refresh after mutation
+- **WHEN** a panel action mutates worktrees or repository configuration
+- **THEN** the panel refreshes and reflects updated state in the same session
+
+#### Scenario: Manual refresh
+- **WHEN** a user invokes panel refresh
+- **THEN** the extension re-queries Arashi state and updates displayed entries

--- a/openspec/changes/create-vscode-plugin/tasks.md
+++ b/openspec/changes/create-vscode-plugin/tasks.md
@@ -1,0 +1,35 @@
+## 1. Extension Scaffold and Baseline Configuration
+
+- [x] 1.1 Initialize the extension project in `repos/arashi-vscode` with TypeScript build/test scripts and contribution points for commands and worktree view.
+- [x] 1.2 Set `engines.vscode` to `^1.96.2` (matching `oil.code`) and verify the manifest remains compatible with VS Code and Cursor.
+- [x] 1.3 Add extension settings for Arashi binary/workspace resolution and startup validation with actionable error messages.
+
+## 2. Command Integration Layer
+
+- [x] 2.1 Implement a shared command runner module that executes Arashi CLI commands, captures stdout/stderr, and normalizes success/failure reporting.
+- [x] 2.2 Register command handlers for `init`, `add`, `create`, `switch`, and `remove` and collect required arguments via native VS Code input/selection/confirmation UI.
+- [x] 2.3 Ensure every command flow that parses CLI output appends `--json` and routes parse failures to clear user-facing errors plus output-channel diagnostics.
+
+## 3. Worktree Panel and Data Pipeline
+
+- [x] 3.1 Implement a `TreeDataProvider` for Arashi worktrees that renders repo, branch, path, and git-change status from CLI data.
+- [x] 3.2 Implement panel discovery/refresh flows backed by CLI JSON responses (`--json`) and preserve last-known state when refresh parsing fails.
+- [x] 3.3 Add empty-state and error-state UX for no worktrees, CLI failures, and invalid workspace configuration.
+
+## 4. Contextual Actions and Confirmation Rules
+
+- [x] 4.1 Add panel actions for switch, remove, and add-repo using the shared command runner and refresh panel state after action completion.
+- [x] 4.2 Require explicit confirmation only for destructive actions (remove/delete) and execute non-destructive actions (switch) without confirmation prompts.
+- [x] 4.3 Ensure all action outcomes produce consistent notifications and output-channel logs with command context.
+
+## 5. Release and Marketplace Publishing
+
+- [x] 5.1 Add packaging and release automation that publishes each production version to VS Marketplace and Open VSX from the same tagged release.
+- [x] 5.2 Add release-time checks that verify version parity and required metadata across both marketplace publishing targets.
+- [x] 5.3 Document installation/upgrade paths for both marketplaces and compatibility expectations for VS Code forks.
+
+## 6. Verification and Quality Gates
+
+- [x] 6.1 Add unit tests for command argument building, `--json` enforcement on parsed commands, cancellation paths, and error normalization.
+- [x] 6.2 Add integration tests for command registration, worktree panel refresh behavior, destructive confirmation behavior, and post-action refresh.
+- [x] 6.3 Run lint, tests, and build in `repos/arashi-vscode`, then validate smoke flows in both VS Code and Cursor.


### PR DESCRIPTION
## Summary
- add the `create-vscode-plugin` OpenSpec change artifacts (proposal, design, specs, tasks) for the VS Code extension initiative
- capture implementation requirements, rollout constraints, and verification checklist used to ship companion extension code

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-vscode/pull/1
- Related issue: https://github.com/corwinm/arashi-arashi/issues/59

Closes #59