### PR TITLE
specs: add vscode additional commands change artifacts

### DIFF
--- a/openspec/changes/vscode-add-additional-commands/.openspec.yaml
+++ b/openspec/changes/vscode-add-additional-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-19

--- a/openspec/changes/vscode-add-additional-commands/design.md
+++ b/openspec/changes/vscode-add-additional-commands/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The current VSCode extension is a proof of concept and does not expose the full set of day-to-day Arashi CLI workflows, specifically missing commands like `pull` and `sync`. The change also includes user-facing consistency work: the extension README should point to the docs site for canonical installation guidance, and extension branding should reuse the docs-site icon.
+
+Key constraints are keeping command behavior aligned with the CLI, avoiding duplicated installation instructions across docs and extension, and ensuring extension assets remain compatible with VSCode Marketplace packaging.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add command-palette support for additional CLI workflows, including `pull` and `sync`.
+- Keep command wiring maintainable by extending existing command registration/execution patterns instead of adding one-off logic.
+- Make installation guidance authoritative by linking extension docs to the docs site.
+- Align extension branding by using the same icon source as the docs site.
+
+**Non-Goals:**
+- Defining or changing CLI command semantics.
+- Redesigning the extension UX beyond adding commands and updating docs/assets.
+- Introducing new telemetry, analytics, or external services.
+
+## Decisions
+
+1. Extend the existing command registration model with new VSCode command IDs for `pull` and `sync`, mapping each to the corresponding CLI invocation.
+   - Rationale: preserves consistency with current extension behavior and reduces maintenance overhead.
+   - Alternative considered: build separate bespoke handlers per command; rejected because it duplicates execution logic and increases drift risk.
+
+2. Reuse the current command execution path (terminal/task process and user-facing error handling) for new commands.
+   - Rationale: keeps execution semantics consistent across all extension commands and avoids introducing a second runtime path.
+   - Alternative considered: direct process spawning per command with custom output handling; rejected due to inconsistent UX and more edge-case handling.
+
+3. Keep extension README installation instructions high-level and link users to docs-site installation pages as the source of truth.
+   - Rationale: reduces documentation drift and centralizes install updates in one place.
+   - Alternative considered: duplicate full install steps in extension README; rejected because updates would need to be synchronized manually.
+
+4. Use the docs-site icon asset as the canonical extension icon source and update VSCode extension metadata/assets accordingly.
+   - Rationale: ensures brand consistency between docs and extension.
+   - Alternative considered: maintain separate extension-only icon; rejected because it creates unnecessary branding divergence.
+
+## Risks / Trade-offs
+
+- [Risk] Users run commands with an older CLI that lacks expected behavior. -> Mitigation: keep failure messages actionable and include docs link for installing/updating CLI.
+- [Risk] README links to install docs become stale over time. -> Mitigation: use stable docs URLs and keep link validation in docs/repo checks where available.
+- [Risk] Icon asset format or size does not meet extension packaging expectations. -> Mitigation: validate icon dimensions/format before packaging and verify metadata references.
+- [Trade-off] Linking to external docs instead of embedding full instructions adds one extra navigation step. -> Mitigation: keep the link prominent and contextual in README onboarding text.
+
+## Migration Plan
+
+1. Add new command contributions and command handlers for `pull` and `sync` in the extension.
+2. Update extension README installation guidance to point to docs-site install instructions.
+3. Replace/update extension icon assets and manifest references to use docs-site icon.
+4. Validate extension behavior locally (command palette + command execution) and package checks.
+5. Release as a non-breaking extension update.
+
+Rollback strategy: revert command contribution/handler additions and asset/readme changes in a patch release if regressions are discovered.
+
+## Open Questions
+
+- What is the exact docs URL path that should be used as the canonical install destination?
+- Should `sync` be exposed as a single command only, or later expanded with optional workflow prompts/flags in the extension UI?

--- a/openspec/changes/vscode-add-additional-commands/proposal.md
+++ b/openspec/changes/vscode-add-additional-commands/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The VSCode extension proof of concept does not yet expose key CLI workflows users need in day-to-day use. Expanding command coverage and improving extension documentation/branding now makes the extension more useful and consistent with the docs experience.
+
+## What Changes
+
+- Add additional VSCode extension commands that were not included in the initial proof of concept, including pull and sync workflows.
+- Update the extension README to direct users to the docs site for full CLI installation guidance.
+- Update the extension icon to use the same icon asset used on the docs site.
+
+## Capabilities
+
+### New Capabilities
+- `vscode-extension-additional-commands`: Adds missing command entries and execution paths in the extension for workflows such as pull and sync.
+- `vscode-extension-install-guidance-linking`: Ensures extension documentation points users to the docs site for authoritative CLI installation instructions.
+- `vscode-extension-icon-alignment`: Aligns extension branding by using the docs-site icon in VSCode extension assets/manifest.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: VSCode extension command registration/execution code, extension README content, and extension icon/manifest assets.
+- User-facing impact: More complete command access from VSCode, clearer installation guidance, and consistent branding.
+- External systems: VSCode command palette surfaces and Marketplace-visible extension metadata/assets.

--- a/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-additional-commands/spec.md
+++ b/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-additional-commands/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Extension exposes pull and sync commands
+The VSCode extension SHALL contribute command palette entries for Arashi `pull` and `sync` workflows.
+
+#### Scenario: Command palette lists pull and sync
+- **WHEN** a user opens the VSCode command palette and searches for Arashi commands
+- **THEN** the extension shows command entries for pull and sync
+
+### Requirement: Extension maps new commands to CLI execution
+The extension SHALL execute the corresponding Arashi CLI command when a user runs the pull or sync command from VSCode.
+
+#### Scenario: Pull command executes CLI pull
+- **WHEN** a user invokes the extension pull command
+- **THEN** the extension starts the Arashi CLI pull workflow
+
+#### Scenario: Sync command executes CLI sync
+- **WHEN** a user invokes the extension sync command
+- **THEN** the extension starts the Arashi CLI sync workflow
+
+### Requirement: Extension surfaces command execution failures
+The extension MUST provide user-visible failure feedback when pull or sync command execution fails.
+
+#### Scenario: Pull or sync command fails
+- **WHEN** the CLI invocation for pull or sync exits with an error
+- **THEN** the extension displays an error message that indicates the command did not complete

--- a/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-icon-alignment/spec.md
+++ b/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-icon-alignment/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Extension uses docs-site-aligned icon asset
+The VSCode extension SHALL use an icon asset aligned with the docs site icon so extension branding is visually consistent across surfaces.
+
+#### Scenario: Marketplace metadata references aligned icon
+- **WHEN** extension metadata is reviewed for icon configuration
+- **THEN** the configured icon asset matches the docs-site-aligned branding asset
+
+### Requirement: Icon asset is valid for VSCode packaging
+The extension icon asset MUST satisfy VSCode extension packaging requirements.
+
+#### Scenario: Extension package validation checks icon
+- **WHEN** the extension is prepared for packaging or publication
+- **THEN** icon validation succeeds without errors related to file format, size, or path resolution

--- a/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-install-guidance-linking/spec.md
+++ b/openspec/changes/vscode-add-additional-commands/specs/vscode-extension-install-guidance-linking/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Extension README links to canonical install docs
+The VSCode extension README SHALL include a link to the docs site installation guidance as the canonical source for Arashi CLI installation.
+
+#### Scenario: User reads installation guidance in README
+- **WHEN** a user opens the extension README and reviews installation instructions
+- **THEN** the README includes a link to the docs site install guidance
+
+### Requirement: Extension README avoids duplicated install procedures
+The extension README MUST avoid embedding full platform-specific installation steps when those steps are maintained on the docs site.
+
+#### Scenario: Installation instructions are maintained centrally
+- **WHEN** the README presents how to install the CLI
+- **THEN** the README provides a concise direction to the docs site instead of duplicating full install procedures

--- a/openspec/changes/vscode-add-additional-commands/tasks.md
+++ b/openspec/changes/vscode-add-additional-commands/tasks.md
@@ -1,0 +1,24 @@
+## 1. Add extension command support
+
+- [x] 1.1 Add VSCode command contributions for Arashi pull and sync in extension metadata
+- [x] 1.2 Register pull and sync command handlers using the existing extension command registration pattern
+- [x] 1.3 Wire pull and sync handlers to invoke the corresponding Arashi CLI commands through the existing execution path
+- [x] 1.4 Add/verify user-visible error messaging when pull or sync CLI execution fails
+
+## 2. Update extension README install guidance
+
+- [x] 2.1 Identify the canonical docs-site URL for Arashi CLI installation instructions
+- [x] 2.2 Update extension README install section to link to the docs-site install guidance
+- [x] 2.3 Remove duplicated platform-specific install steps from extension README while preserving concise onboarding context
+
+## 3. Align extension icon branding
+
+- [x] 3.1 Copy or reference the docs-site-aligned icon asset for the VSCode extension
+- [x] 3.2 Update extension manifest/icon metadata to point at the aligned icon asset path
+- [x] 3.3 Verify icon file format and dimensions satisfy VSCode extension packaging requirements
+
+## 4. Validate and prepare release
+
+- [x] 4.1 Verify command palette shows pull and sync and both execute successfully in a local extension run
+- [x] 4.2 Verify README renders correct docs-site installation link in extension repository/marketplace context
+- [x] 4.3 Run extension packaging/build checks and confirm no icon or metadata validation errors


### PR DESCRIPTION
## Summary
- Add a complete OpenSpec change set for adding VSCode extension commands (`pull`, `sync`) plus docs-link and icon alignment requirements.
- Capture proposal, design decisions, capability specs, and implementation tasks for the coordinated extension update.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-vscode/pull/2
- Related issue: https://github.com/corwinm/arashi-arashi/issues/109
- Closes #109