### PR TITLE
specs: add clone-command artifacts

### DIFF
--- a/openspec/changes/clone-command/.openspec.yaml
+++ b/openspec/changes/clone-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-19

--- a/openspec/changes/clone-command/design.md
+++ b/openspec/changes/clone-command/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The workspace currently has no dedicated command for cloning repositories that are already configured but missing locally. This causes confusing workflows during first-time setup and when teammates add repositories later. Related UX issues already exist in `status` (missing repositories surface as git spawn errors) and `add` (duplicate-repository guidance suggests incorrect remediation).
+
+The change introduces a clone-focused workflow that must coordinate CLI command behavior, repository/config metadata, filesystem discovery, and user prompts across interactive and automation-friendly modes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a first-class `arashi clone` command that clones only missing configured repositories.
+- Support default interactive selection and a non-interactive clone-all path.
+- Reconcile unmanaged local repositories with explicit user actions (add to config, delete, ignore).
+- Keep clone URL protocol usage (SSH/HTTPS) consistent per user when possible.
+- Replace misleading `status` and `add` guidance with clone-oriented remediation.
+
+**Non-Goals:**
+- Redesigning full repository lifecycle semantics beyond clone/setup discovery flows.
+- Supporting non-git repository sources.
+- Persisting long-term audit history of clone/reconciliation actions.
+
+## Decisions
+
+### 1) Add a dedicated clone command with two execution modes
+- **Decision:** Implement `arashi clone` with default interactive selection and `--all` for non-interactive cloning of all missing configured repositories.
+- **Rationale:** Interactive mode is safest for day-to-day use; `--all` supports automation and first-time bootstrap.
+- **Alternatives considered:**
+  - Extend `setup` only: rejected because clone-specific discovery and reconciliation become harder to discover and reason about.
+  - Make clone always non-interactive: rejected due to higher accidental clone risk and worse UX for selective workflows.
+
+### 2) Normalize repository metadata to include clone URL
+- **Decision:** Ensure each configured repository has a persisted git URL usable by clone operations; update `add` to always store URL metadata.
+- **Rationale:** Clone cannot be reliable without canonical source URL data in configuration.
+- **Alternatives considered:**
+  - Infer URL from local clones only: rejected because missing repos have no local remote to inspect.
+  - Require URL input every clone run: rejected due to poor UX and duplicated user effort.
+
+### 3) Use a discovery classification pipeline before prompt/rendering
+- **Decision:** Build a single discovery pass that classifies repositories into:
+  - configured + present
+  - configured + missing (clone candidates)
+  - local + unmanaged (not in config)
+- **Rationale:** A structured classification model keeps prompt logic deterministic and reusable across `clone`, `status`, and `add` fallbacks.
+- **Alternatives considered:**
+  - Inline checks inside each command: rejected due to duplicated logic and inconsistent edge-case behavior.
+
+### 4) Infer protocol preference from existing URLs, prompt only when ambiguous
+- **Decision:** Infer SSH/HTTPS preference from existing configured repository URLs (or local remotes when needed). If no clear preference exists, prompt once per clone operation.
+- **Rationale:** Preserves user conventions while avoiding unnecessary prompts.
+- **Alternatives considered:**
+  - Force HTTPS: rejected because many teams standardize on SSH keys.
+  - Always ask: rejected as noisy for repeated runs.
+
+### 5) Integrate clone-aware remediation into status and add
+- **Decision:**
+  - `status`: when a configured repository path is missing, emit actionable guidance to run `arashi clone` instead of attempting git commands.
+  - `add`: when repository is already configured, provide clone-oriented guidance and offer fallback to clone flow rather than rename/remove suggestions.
+- **Rationale:** Reduces user confusion and connects users to the intended command path.
+- **Alternatives considered:**
+  - Keep current messaging with docs-only fix: rejected because runtime output remains misleading.
+
+## Risks / Trade-offs
+
+- [Config migration gaps for existing entries without URLs] -> Add validation and a repair path that prompts for URL or derives from local remotes when available.
+- [Protocol inference may be wrong in mixed SSH/HTTPS workspaces] -> Use explicit tie/ambiguity detection and prompt before cloning.
+- [Unmanaged local repo deletion is destructive] -> Require explicit confirmation and default to non-destructive options.
+- [Cross-command coupling increases maintenance cost] -> Centralize discovery/remediation helpers in shared utilities with focused tests.
+
+## Migration Plan
+
+1. Extend config schema handling to support required repository URL metadata with backward-compatible reads.
+2. Update `add` command to persist URL metadata consistently.
+3. Implement shared discovery classification utilities and protocol inference helpers.
+4. Implement `clone` command interactive and `--all` paths, including unmanaged repo reconciliation prompts.
+5. Update `status` missing-repository behavior and `add` duplicate-repository remediation flow.
+6. Roll out docs/skills/VS Code extension updates after CLI behavior is stable.
+
+## Open Questions
+
+- Should unmanaged local repository "delete" support trash/recycle semantics on supported platforms, or remain hard delete with confirmation?
+- Should protocol preference be persisted in config for future runs, or inferred each time from repository URLs?

--- a/openspec/changes/clone-command/proposal.md
+++ b/openspec/changes/clone-command/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Developers cannot reliably sync local repositories with workspace configuration when a repository is newly added or missing, and current command messaging is misleading in these cases. We need a dedicated clone workflow now to make first-time setup and ongoing repo synchronization predictable, interactive, and consistent.
+
+## What Changes
+
+- Add an `arashi clone` command that discovers missing configured repositories and interactively lets users choose which repositories to clone by default.
+- Add a non-interactive option to clone all missing configured repositories in one command.
+- Detect repositories already present locally and only present missing repositories as clone targets.
+- Detect local repositories not present in configuration and provide guided options to add to config, delete local clone, or ignore.
+- Update repository metadata handling so configured repositories store git URLs needed for clone operations.
+- Improve `arashi status` output for missing repositories to suggest `arashi clone` instead of surfacing git spawn errors.
+- Update `arashi add` duplicate-repository handling to suggest and optionally route users to `arashi clone` instead of misleading rename/remove guidance.
+- Use a consistent clone protocol (SSH or HTTPS) based on existing user repository URLs, with an explicit prompt when protocol preference cannot be inferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `clone-command`: Clone missing configured repositories with interactive selection and clone-all support.
+- `clone-discovery-and-reconciliation`: Detect missing configured repos and unmanaged local repos, then guide reconciliation actions.
+- `clone-protocol-preference`: Infer and apply per-user SSH/HTTPS clone protocol consistency.
+
+### Modified Capabilities
+
+- `status-command`: Replace missing-repository git error path with actionable guidance to run `arashi clone`.
+- `add-command`: Replace duplicate-repository remediation flow with clone-oriented guidance and optional fallback to clone workflow.
+
+## Impact
+
+- Affected code areas: CLI command surface (`clone`, `status`, `add`), repository/config management utilities, and prompt flows.
+- Affected configuration/data: workspace repository entries must include cloneable git URL metadata.
+- Affected docs/tooling: user docs and related integration surfaces (docs, skills, VS Code extension command guidance).
+- External dependencies: git operations and network access for repository cloning.

--- a/openspec/changes/clone-command/specs/add-command/spec.md
+++ b/openspec/changes/clone-command/specs/add-command/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Duplicate configured repository guidance points to clone workflow
+The add command SHALL detect when a repository already exists in workspace configuration and SHALL present clone-oriented guidance instead of rename/remove remediation.
+
+#### Scenario: Repository already configured
+- **WHEN** the user runs `arashi add <git-url>` and the repository name already exists in configuration
+- **THEN** the command reports that the repository is already configured and recommends `arashi clone` to obtain a missing local copy
+
+### Requirement: Offer clone fallback after duplicate detection
+The add command SHALL offer a fallback path to start the clone workflow when duplicate configuration is detected in interactive terminals.
+
+#### Scenario: User accepts clone fallback
+- **WHEN** duplicate configuration is detected and the user accepts the clone fallback prompt
+- **THEN** the command starts the clone workflow for missing configured repositories
+
+#### Scenario: User declines clone fallback
+- **WHEN** duplicate configuration is detected and the user declines the clone fallback prompt
+- **THEN** the command exits without changing configuration or removing repositories
+
+### Requirement: Remove incorrect remove-command guidance from duplicate errors
+The add command MUST NOT suggest `arashi remove` as remediation for a duplicate configured repository discovered during add.
+
+#### Scenario: Duplicate add error output
+- **WHEN** the command reports a duplicate configured repository
+- **THEN** the output omits suggestions to remove repositories via `arashi remove`

--- a/openspec/changes/clone-command/specs/clone-command/spec.md
+++ b/openspec/changes/clone-command/specs/clone-command/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Clone missing configured repositories
+The system SHALL provide an `arashi clone` command that discovers configured repositories missing from the local workspace and limits clone candidates to those missing repositories.
+
+#### Scenario: Missing repositories are discovered
+- **WHEN** the user runs `arashi clone` and one or more configured repositories are not present locally
+- **THEN** the command returns those missing repositories as clone candidates
+
+#### Scenario: No repositories are missing
+- **WHEN** the user runs `arashi clone` and all configured repositories are already present locally
+- **THEN** the command exits successfully with a message indicating there are no repositories to clone
+
+### Requirement: Interactive selection is the default clone mode
+The system SHALL run in interactive selection mode by default and SHALL allow the user to select one or more missing repositories to clone.
+
+#### Scenario: Interactive clone selection
+- **WHEN** the user runs `arashi clone` in an interactive terminal with multiple missing repositories
+- **THEN** the command prompts for repository selection before executing clone operations
+
+### Requirement: Clone all missing repositories non-interactively
+The system SHALL support a non-interactive `--all` mode that clones every missing configured repository without presenting a selection prompt.
+
+#### Scenario: Clone all mode
+- **WHEN** the user runs `arashi clone --all`
+- **THEN** the command clones all missing configured repositories and does not ask for interactive selection
+
+### Requirement: Clone command reports per-repository outcomes
+The system SHALL report clone success or failure for each selected repository and SHALL continue attempting remaining selected repositories when one clone fails.
+
+#### Scenario: One repository clone fails
+- **WHEN** the command processes multiple selected repositories and one clone operation fails
+- **THEN** the command reports the failure for that repository and continues cloning remaining selected repositories

--- a/openspec/changes/clone-command/specs/clone-discovery-and-reconciliation/spec.md
+++ b/openspec/changes/clone-command/specs/clone-discovery-and-reconciliation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Classify repository workspace state before clone actions
+The system SHALL classify repository state before clone execution into configured-present, configured-missing, and local-unmanaged groups.
+
+#### Scenario: Workspace has mixed repository states
+- **WHEN** the user runs `arashi clone` and the workspace contains configured and unmanaged repositories
+- **THEN** the command classifies repositories into configured-present, configured-missing, and local-unmanaged groups
+
+### Requirement: Reconcile unmanaged local repositories
+The system SHALL provide reconciliation options for unmanaged local repositories: add to configuration, delete local repository, or take no action.
+
+#### Scenario: User adds unmanaged repository to configuration
+- **WHEN** an unmanaged local repository is detected and the user chooses add-to-configuration
+- **THEN** the command records the repository in workspace configuration with required metadata
+
+#### Scenario: User deletes unmanaged repository
+- **WHEN** an unmanaged local repository is detected and the user chooses delete
+- **THEN** the command requests explicit confirmation before deleting the local repository
+
+#### Scenario: User keeps unmanaged repository unchanged
+- **WHEN** an unmanaged local repository is detected and the user chooses no action
+- **THEN** the command leaves the local repository and configuration unchanged
+
+### Requirement: Ignore already present configured repositories during clone target selection
+The system SHALL exclude configured-present repositories from clone target prompts and clone-all execution.
+
+#### Scenario: Configured repository is already cloned
+- **WHEN** the user runs `arashi clone` and a configured repository already exists at its expected local path
+- **THEN** that repository is not offered as a clone target

--- a/openspec/changes/clone-command/specs/clone-protocol-preference/spec.md
+++ b/openspec/changes/clone-command/specs/clone-protocol-preference/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Infer preferred clone protocol from workspace data
+The system SHALL infer the user's preferred clone protocol from existing repository URL metadata and SHALL use that preference for clone operations when the preference is unambiguous.
+
+#### Scenario: SSH preference is inferred
+- **WHEN** existing configured repository URLs are consistently SSH-formatted
+- **THEN** clone operations use SSH-formatted repository URLs for missing repositories
+
+#### Scenario: HTTPS preference is inferred
+- **WHEN** existing configured repository URLs are consistently HTTPS-formatted
+- **THEN** clone operations use HTTPS-formatted repository URLs for missing repositories
+
+### Requirement: Prompt when protocol preference is ambiguous or unavailable
+The system SHALL prompt the user to choose SSH or HTTPS when protocol preference cannot be inferred with confidence.
+
+#### Scenario: No existing URL data
+- **WHEN** the user runs `arashi clone` and the workspace has no repository URLs from which to infer protocol
+- **THEN** the command prompts the user to choose SSH or HTTPS before cloning
+
+#### Scenario: Mixed protocol workspace
+- **WHEN** existing repository URLs contain a mixed set of SSH and HTTPS formats
+- **THEN** the command prompts the user to choose SSH or HTTPS before cloning
+
+### Requirement: Apply selected protocol consistently within one run
+The system SHALL apply the inferred or user-selected protocol consistently to all clone operations in the current command execution.
+
+#### Scenario: Multiple repositories cloned in one run
+- **WHEN** the user clones multiple repositories in a single command invocation
+- **THEN** every clone operation in that run uses the same protocol choice

--- a/openspec/changes/clone-command/specs/status-command/spec.md
+++ b/openspec/changes/clone-command/specs/status-command/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Report missing configured repositories with actionable guidance
+The status command SHALL detect configured repositories that are missing on disk and SHALL report them as missing repositories with guidance to run `arashi clone`.
+
+#### Scenario: Configured repository path is missing
+- **WHEN** the user runs `arashi status` and a configured repository directory does not exist locally
+- **THEN** status output marks that repository as missing and includes guidance to run `arashi clone`
+
+### Requirement: Avoid git execution for missing repository paths
+The status command MUST NOT run git subprocess operations for repositories whose configured local path is missing.
+
+#### Scenario: Missing repository would previously trigger git spawn failure
+- **WHEN** the user runs `arashi status` and a configured repository path is absent
+- **THEN** the command does not attempt git operations for that repository and does not emit a git spawn ENOENT error for that case

--- a/openspec/changes/clone-command/tasks.md
+++ b/openspec/changes/clone-command/tasks.md
@@ -1,0 +1,37 @@
+## 1. Repository metadata and configuration groundwork
+
+- [x] 1.1 Update workspace repository config handling to persist cloneable git URLs for every configured repository
+- [x] 1.2 Add backward-compatible read and repair behavior for existing config entries that do not yet include URLs
+- [x] 1.3 Add unit tests for URL persistence, validation, and migration/repair paths
+
+## 2. Discovery and protocol utilities
+
+- [x] 2.1 Implement shared repository state classification (configured-present, configured-missing, local-unmanaged)
+- [x] 2.2 Implement protocol preference inference (SSH/HTTPS) with ambiguity detection and prompt fallback
+- [x] 2.3 Add focused unit tests for discovery classification and protocol selection behavior
+
+## 3. Clone command implementation
+
+- [x] 3.1 Add and register `arashi clone` command with default interactive mode and `--all` non-interactive mode
+- [x] 3.2 Implement clone candidate selection to include only configured-missing repositories
+- [x] 3.3 Implement clone execution with per-repository success/failure reporting and continue-on-failure behavior
+- [x] 3.4 Implement unmanaged local repository reconciliation prompts (add to config, delete with explicit confirmation, ignore)
+- [x] 3.5 Add integration tests for no-missing, interactive-selection, `--all`, and partial-failure clone flows
+
+## 4. Status and add command remediation updates
+
+- [x] 4.1 Update `arashi status` to detect missing repository paths, skip git subprocess calls, and show `arashi clone` guidance
+- [x] 4.2 Update duplicate handling in `arashi add` to recommend clone workflow and offer interactive clone fallback
+- [x] 4.3 Remove incorrect `arashi remove` remediation suggestions from duplicate add output and add regression tests
+
+## 5. Documentation and companion surface updates
+
+- [x] 5.1 Update CLI docs with clone command behavior, options, reconciliation flow, and protocol selection rules
+- [x] 5.2 Update related Skills and VS Code integration documentation/command guidance to reference `arashi clone`
+- [x] 5.3 Document first-time setup and missing-repository recovery examples for team onboarding
+
+## 6. Validation and readiness
+
+- [x] 6.1 Run required quality checks in `repos/arashi`: `bun run lint` and `bun test`
+- [x] 6.2 Run recommended build verification in `repos/arashi`: `bun run build`
+- [x] 6.3 Perform end-to-end manual verification in a mixed workspace state and capture follow-up issues if gaps remain


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal, design, capability specs, and implementation tasks for the clone command initiative.
- Define clone behavior, protocol preference handling, and add/status guidance changes tied to the implementation work.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/38, https://github.com/corwinm/arashi-docs/pull/7, https://github.com/corwinm/arashi-skills/pull/7, https://github.com/corwinm/arashi-vscode/pull/3
- Related issue: https://github.com/corwinm/arashi-arashi/issues/87
- Closes #87