### PR TITLE
specs: add config schema migration artifacts

### DIFF
--- a/openspec/changes/create-json-schema-for-arashi-config/.openspec.yaml
+++ b/openspec/changes/create-json-schema-for-arashi-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-22

--- a/openspec/changes/create-json-schema-for-arashi-config/design.md
+++ b/openspec/changes/create-json-schema-for-arashi-config/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Arashi currently validates `.arashi/config.json` with hand-written TypeScript checks in `repos/arashi/src/lib/config.ts`, and the persisted shape still uses snake_case keys such as `repos_dir`, `auto_setup`, and `discovered_repos`. This makes external validation/editor support difficult and allows drift between runtime types, docs, and actual saved config. The change needs a generated JSON Schema published at `https://arashi.haphazard.dev/config.json`, plus a move to canonical camelCase config keys.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define one canonical config model in TypeScript and generate JSON Schema from it.
+- Publish schema artifacts with a stable URL and version-pinned usage guidance.
+- Migrate persisted config shape to camelCase, including renaming `discoveredRepos` to `repos`.
+- Remove persisted fields that are derived/runtime-only so config remains stable and user-editable.
+- Add CI checks that fail on schema drift.
+
+**Non-Goals:**
+- Re-architect worktree orchestration behavior or repository discovery semantics.
+- Introduce a second independently maintained schema source.
+- Solve all historical config migrations beyond legacy key normalization needed for this release.
+
+## Decisions
+
+1) Canonical config contract is TypeScript-first
+- Decision: keep TypeScript interfaces as source of truth and generate schema from exported `Config` type.
+- Why: removes duplication and prevents schema/docs/runtime mismatch.
+- Alternatives considered:
+  - Hand-authored schema file: rejected due maintenance drift risk.
+  - Runtime introspection-only validation: rejected because users/editors still need a distributable schema.
+
+2) Add deterministic schema generation pipeline
+- Decision: add `ts-json-schema-generator` as pinned dev dependency; generate to `repos/arashi/schema/config.schema.json` via a dedicated script.
+- Why: deterministic output supports reviewability and CI drift checks.
+- Alternatives considered:
+  - Unpinned generator version: rejected because output changes can break CI unexpectedly.
+  - Generate only in CI: rejected because contributors need local regeneration workflow.
+
+3) Canonical persisted config uses camelCase and `repos`
+- Decision: migrate root and nested persisted keys to camelCase, with repository map named `repos`.
+- Why: consistent naming improves readability and aligns with modern TypeScript usage.
+- Alternatives considered:
+  - Keep snake_case in storage and map only in memory: rejected as confusing for users editing JSON directly.
+
+4) Persist only durable repository configuration
+- Decision: stop persisting values that can be recomputed or quickly refreshed (`defaultBranch`, `isBare`, `worktrees`) unless specs require a clear persisted use case.
+- Why: these values become stale and create user-facing confusion when they differ from live git state.
+- Alternatives considered:
+  - Keep all current fields for backward compatibility: rejected due long-term schema bloat and stale metadata risk.
+
+5) Backward-compatible read, forward-only write
+- Decision: loader accepts legacy keys (`repos_dir`, `auto_setup`, `discovered_repos`, nested snake_case keys), normalizes to canonical model, and save paths always write new camelCase shape.
+- Why: existing workspaces continue to function while converging quickly to one format.
+- Alternatives considered:
+  - Hard break without compatibility layer: rejected because it forces immediate manual migration.
+
+6) Public schema publishing path
+- Decision: publish generated schema to the docs site root as `config.json` so `https://arashi.haphazard.dev/config.json` always resolves.
+- Why: this matches requested URL and keeps schema hosting tied to docs deployment lifecycle.
+- Alternatives considered:
+  - Rely only on npm CDN URL: rejected because issue requires first-party URL.
+
+## Risks / Trade-offs
+
+- [Risk] Legacy config parsing misses edge-case keys and breaks older workspaces -> Mitigation: add fixture-based tests for legacy + canonical configs and normalize before validation.
+- [Risk] Removing persisted fields affects commands that implicitly rely on cached metadata -> Mitigation: audit call sites and compute these values from git/runtime where needed.
+- [Risk] Generated schema diverges from docs-hosted file -> Mitigation: CI step regenerates schema and verifies committed/generated/hosted artifacts match.
+- [Risk] Strict `additionalProperties: false` blocks user custom fields -> Mitigation: allow extensibility only in explicitly flexible objects (for example `metadata`) and document boundaries.
+
+## Migration Plan
+
+1. Introduce canonical camelCase TypeScript config types and temporary legacy-to-canonical normalization helpers.
+2. Update load/validate/save paths to normalize legacy input, validate canonical structure, and write canonical JSON only.
+3. Add schema generation script and generated schema artifact in `repos/arashi/schema/`.
+4. Wire schema publication to docs output path for `config.json` and update docs/examples to include `$schema`.
+5. Add CI guardrails for schema regeneration drift and run lint/tests/build.
+6. Rollback strategy: if migration causes regressions, re-enable legacy write mode behind a short-term compatibility flag while keeping canonical read support.
+
+## Open Questions
+
+- Should `schemaVersion` be introduced now, or should the existing `version` field remain the only versioning signal?
+- Do we need a deprecation warning window before fully removing any persisted derived repo fields from existing files?

--- a/openspec/changes/create-json-schema-for-arashi-config/proposal.md
+++ b/openspec/changes/create-json-schema-for-arashi-config/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Arashi users need a machine-readable contract for `.arashi/config.json` so editors can validate and autocomplete config updates safely. We should define and publish a canonical JSON Schema now because config keys have drifted (naming, legacy fields, and unclear required properties), which increases support and migration risk.
+
+## What Changes
+
+- Generate a JSON Schema for `.arashi/config.json` from the TypeScript `Config` type and store the generated artifact in the repository.
+- Publish the schema at a stable public URL (`https://arashi.haphazard.dev/config.json`) with version-pinned guidance for consumers.
+- Normalize config field naming to camelCase and rename `discoveredRepos` to `repos`.
+- Audit config shape and remove obsolete stored fields that are not required by current runtime behavior.
+- Define strict schema behavior (required fields and `additionalProperties: false`) and add CI checks so generated schema stays in sync.
+- Update docs and init/config examples so users can attach `$schema` to local config files.
+
+## Capabilities
+
+### New Capabilities
+
+- `config-json-schema`: Generate, publish, and validate a JSON Schema contract for `.arashi/config.json`, including documentation for `$schema` usage.
+
+### Modified Capabilities
+
+- `config-management`: Update config requirements to use camelCase keys, rename `discoveredRepos` to `repos`, and remove no-longer-needed persisted fields.
+
+## Impact
+
+- Affected code: config types/loaders/writers, init/setup flows, release/publish scripts, and documentation pages.
+- Affected artifacts: generated schema file(s), package publishing metadata, and CI validation for schema drift.
+- External impact: users editing config manually gain validation/autocomplete support; legacy config keys may require migration handling.
+- Dependencies: JSON Schema generation tooling and schema hosting/publishing path.

--- a/openspec/changes/create-json-schema-for-arashi-config/specs/config-json-schema/spec.md
+++ b/openspec/changes/create-json-schema-for-arashi-config/specs/config-json-schema/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Generate schema from canonical TypeScript config model
+The system MUST generate a JSON Schema for `.arashi/config.json` from the canonical exported TypeScript `Config` type so runtime config behavior and schema remain aligned.
+
+#### Scenario: Schema generation succeeds from source type
+- **WHEN** a contributor runs the schema generation command
+- **THEN** the tool produces a schema file from the `Config` type without manual schema authoring
+
+#### Scenario: Generated schema reflects required config fields
+- **WHEN** schema generation completes
+- **THEN** the generated schema marks canonical required root properties and nested required properties based on the TypeScript model
+
+### Requirement: Enforce strict config structure in schema
+The generated schema MUST set `additionalProperties: false` for objects with fixed structure and MUST constrain documented field types so invalid keys and invalid types are rejected.
+
+#### Scenario: Unknown root property is rejected by schema
+- **WHEN** a config file includes an unknown root key not defined in the schema
+- **THEN** schema validation fails with an additional properties violation
+
+#### Scenario: Invalid property type is rejected by schema
+- **WHEN** a config file provides a value with the wrong type for a defined property
+- **THEN** schema validation fails for that property
+
+### Requirement: Publish schema at stable Arashi URL
+The system MUST publish the generated schema at `https://arashi.haphazard.dev/config.json` for each release so editors and users can resolve a stable public schema endpoint.
+
+#### Scenario: Published docs expose schema path
+- **WHEN** docs artifacts are deployed
+- **THEN** `https://arashi.haphazard.dev/config.json` resolves to the current generated schema
+
+#### Scenario: Documentation includes version-pinned usage guidance
+- **WHEN** a user reads configuration documentation
+- **THEN** docs provide guidance for both stable URL usage and version-pinned schema references
+
+### Requirement: Detect schema drift in CI
+The project MUST fail CI when the committed schema does not match the schema regenerated from the current TypeScript config model.
+
+#### Scenario: CI fails on stale committed schema
+- **WHEN** config types change and schema file is not regenerated
+- **THEN** CI reports schema drift and exits with failure
+
+#### Scenario: CI passes when schema is up to date
+- **WHEN** committed schema matches regenerated output
+- **THEN** schema validation steps in CI succeed

--- a/openspec/changes/create-json-schema-for-arashi-config/specs/config-management/spec.md
+++ b/openspec/changes/create-json-schema-for-arashi-config/specs/config-management/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Configuration persistence uses canonical camelCase keys
+The system MUST persist `.arashi/config.json` using canonical camelCase keys for all root and nested properties, including `reposDir`, `autoSetup`, and repository-level fields such as `gitUrl`.
+
+#### Scenario: New config is written in canonical key format
+- **WHEN** the system initializes a new config file
+- **THEN** the written JSON uses canonical camelCase keys only
+
+#### Scenario: Existing config is saved after mutation
+- **WHEN** a loaded config is modified and saved
+- **THEN** the saved file is normalized to canonical camelCase keys
+
+### Requirement: Repository collection key is `repos`
+The system MUST use `repos` as the canonical root repository map key in persisted configuration and internal normalized representation.
+
+#### Scenario: Config save writes repository map as repos
+- **WHEN** one or more repositories are present in configuration
+- **THEN** persisted config stores them under `repos`
+
+#### Scenario: Legacy repository map key is accepted for compatibility
+- **WHEN** a legacy config contains `discovered_repos` or `discoveredRepos`
+- **THEN** load normalization maps entries to canonical `repos` without data loss
+
+### Requirement: Derived repository metadata is not persisted
+The system MUST NOT persist repository metadata fields that are derivable from live git state, including `defaultBranch`, `isBare`, and `worktrees`, unless explicitly reintroduced by a future requirement.
+
+#### Scenario: Save omits derived metadata fields
+- **WHEN** repository entries in memory include derived metadata values
+- **THEN** persisted config excludes those fields
+
+#### Scenario: Runtime still functions without persisted derived metadata
+- **WHEN** commands require branch, bare, or worktree state
+- **THEN** the system resolves that state from git/runtime sources rather than expecting persisted cache fields
+
+### Requirement: Legacy config keys remain readable during migration
+The system MUST load legacy snake_case configuration keys for backward compatibility and normalize them into canonical keys before validation and downstream use.
+
+#### Scenario: Legacy config loads successfully
+- **WHEN** a workspace contains a valid legacy snake_case config
+- **THEN** config loading succeeds and returns canonical normalized structure
+
+#### Scenario: Invalid legacy shape still fails validation
+- **WHEN** a legacy config has missing required fields or invalid types
+- **THEN** validation fails with actionable errors referencing the invalid fields

--- a/openspec/changes/create-json-schema-for-arashi-config/tasks.md
+++ b/openspec/changes/create-json-schema-for-arashi-config/tasks.md
@@ -1,0 +1,31 @@
+## 1. Canonical Config Model
+
+- [x] 1.1 Define canonical camelCase config interfaces in `repos/arashi/src/lib/config.ts` with root `repos` map and repository `gitUrl` keys.
+- [x] 1.2 Add legacy-to-canonical normalization for root and nested snake_case keys during config load.
+- [x] 1.3 Update config validation to validate canonical shape and enforce rejection of unknown fixed-structure properties.
+- [x] 1.4 Update config save paths to always write canonical camelCase JSON.
+
+## 2. Repository Metadata Persistence Cleanup
+
+- [x] 2.1 Remove persisted `defaultBranch`, `isBare`, and `worktrees` from repository config writes.
+- [x] 2.2 Audit command call sites that currently read those fields and switch them to runtime/git-derived values.
+- [x] 2.3 Add migration-safe behavior so legacy files with removed fields still load successfully.
+
+## 3. JSON Schema Generation
+
+- [x] 3.1 Add pinned `ts-json-schema-generator` dev dependency and create a schema generation script in `repos/arashi/package.json`.
+- [x] 3.2 Generate and commit `repos/arashi/schema/config.schema.json` from the exported `Config` type.
+- [x] 3.3 Ensure package/release metadata includes the generated schema artifact for distribution.
+
+## 4. Schema Publication and Documentation
+
+- [x] 4.1 Wire docs/site output so `https://arashi.haphazard.dev/config.json` serves the generated schema.
+- [x] 4.2 Update config documentation with `$schema` examples for stable URL and version-pinned usage.
+- [x] 4.3 Update init/config templates so generated config references the canonical schema URL where applicable.
+
+## 5. Validation, CI, and Tests
+
+- [x] 5.1 Add CI check to regenerate schema and fail when committed schema differs.
+- [x] 5.2 Add unit tests for legacy key normalization, camelCase persistence, and rejected invalid/unknown fields.
+- [x] 5.3 Add tests that verify removed derived repo fields are not persisted while runtime behavior remains correct.
+- [x] 5.4 Run required quality checks in `repos/arashi` (`bun run lint`, `bun test`) and recommended build (`bun run build`).


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal, design, specs, and tasks for introducing generated JSON Schema support for `.arashi/config.json`.
- Define canonical config requirements and migration behavior used by downstream implementation repos.
- Capture implementation sequencing for schema generation, publication, CI drift checks, and verification coverage.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/39, https://github.com/corwinm/arashi-docs/pull/8, https://github.com/corwinm/arashi-vscode/pull/4
- Related issue: https://github.com/corwinm/arashi-arashi/issues/97

Closes #97