### PR TITLE
specs: add configurable worktree location change artifacts

### DIFF
--- a/openspec/changes/add-config-option-for-worktrees-locations/.openspec.yaml
+++ b/openspec/changes/add-config-option-for-worktrees-locations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-22

--- a/openspec/changes/add-config-option-for-worktrees-locations/design.md
+++ b/openspec/changes/add-config-option-for-worktrees-locations/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Arashi currently does not expose a user-facing setting for where worktrees are created, so destination paths are effectively fixed by command behavior. This makes it difficult to support different workspace layouts, including sibling directories (`../`), repo-root placement (`.`/`./`), or managed subdirectories. The proposal requires a configurable location with consistent normalization and a safe default of `.arashi/worktrees/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a first-class config option that controls the base path used for new worktree directories.
+- Support relative path inputs such as `../`, `.`, `./`, and `.arashi/worktrees` with optional trailing slashes.
+- Resolve and normalize configured paths consistently before any command creates worktrees.
+- Preserve a stable default (`.arashi/worktrees/`) when the option is not configured.
+- Ensure default managed directories are ignored by git when appropriate.
+
+**Non-Goals:**
+- Introducing per-command/per-repo overrides for worktree location in this change.
+- Redesigning repository discovery, branch naming, or worktree lifecycle behavior.
+- Moving existing worktrees automatically as part of this rollout.
+
+## Decisions
+
+1) Add an explicit workspace-level worktree location setting
+- Decision: introduce a dedicated config field for the worktree base location and normalize it to one canonical in-memory representation.
+- Why: an explicit field removes hidden path logic and lets users choose a layout intentionally.
+- Alternatives considered:
+  - Hard-code one location forever: rejected because it blocks valid workspace layouts.
+  - Infer location from repo metadata only: rejected because users need direct control.
+
+2) Treat configured values as workspace-relative paths
+- Decision: resolve configured locations relative to the workspace root and normalize path forms by trimming optional trailing slashes and collapsing dot segments.
+- Why: relative paths keep configuration portable across machines and repositories.
+- Alternatives considered:
+  - Allow absolute paths as first-class values: rejected for now to avoid portability and security surprises.
+
+3) Centralize destination resolution in one utility
+- Decision: add a shared path-resolution utility used by all commands that create or register worktrees.
+- Why: centralizing behavior avoids inconsistent handling between `add`, `create`, and related orchestration flows.
+- Alternatives considered:
+  - Resolve ad hoc in each command: rejected due drift risk and duplicated validation logic.
+
+4) Keep backward compatibility while defining default behavior
+- Decision: if the setting is missing, use `.arashi/worktrees/` as the default output base; initialization/setup paths should write or imply this default clearly.
+- Why: this gives predictable behavior for new and existing users without requiring manual migration.
+- Alternatives considered:
+  - Require explicit configuration everywhere: rejected because it adds friction and breaks existing workflows.
+
+5) Manage git ignore only for the default managed directory
+- Decision: ensure `.arashi/worktrees/` is ignored when used as default managed storage; do not automatically modify ignore rules for arbitrary custom paths.
+- Why: auto-updating ignore rules for custom user paths can create unexpected repository changes.
+- Alternatives considered:
+  - Auto-ignore every configured path: rejected because custom locations may intentionally be tracked.
+
+## Risks / Trade-offs
+
+- [Risk] Path normalization differences create subtle command behavior mismatches -> Mitigation: enforce one resolver with integration tests for `../`, `.`, `./`, and trailing slash variants.
+- [Risk] Existing workspaces without the new setting behave unexpectedly -> Mitigation: preserve default fallback and add regression tests for omitted configuration.
+- [Risk] Rejecting absolute paths may be too strict for some teams -> Mitigation: document this constraint and revisit via a follow-up change if needed.
+- [Risk] Default ignore updates may conflict with existing `.gitignore` conventions -> Mitigation: implement idempotent, minimal ignore insertion with tests.
+
+## Migration Plan
+
+1. Introduce config parsing/validation for the new worktree location option with normalization.
+2. Add shared resolver utility and migrate worktree-creating code paths to use it.
+3. Apply default fallback behavior for existing configs without the new option.
+4. Update setup/init flows to ensure default managed directory ignore behavior is present and idempotent.
+5. Add unit/integration tests for path variants, fallback behavior, and ignore handling.
+
+## Open Questions
+
+- Should absolute paths be accepted later behind an explicit opt-in for advanced users?
+- Should future iterations allow per-repository overrides in addition to a workspace default?

--- a/openspec/changes/add-config-option-for-worktrees-locations/proposal.md
+++ b/openspec/changes/add-config-option-for-worktrees-locations/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Worktree locations are currently not configurable, which makes it hard to fit different repository layouts and team preferences. We need a first-class configuration option now so users can place generated worktrees in predictable locations such as a sibling directory, repo root, or a managed subdirectory.
+
+## What Changes
+
+- Add a workspace configuration option that controls the base directory used when creating worktrees.
+- Support common relative path inputs including `../`, `.`, `./`, and `.arashi/worktrees`, with optional trailing slashes.
+- Normalize and resolve configured paths consistently before worktree creation.
+- Default to `.arashi/worktrees/` when the option is omitted.
+- Ensure the default managed worktree directory is ignored by git when needed.
+
+## Capabilities
+
+### New Capabilities
+- `configurable-worktree-location`: Allow users to configure where Arashi creates worktrees, including defaulting, normalization, and path resolution behavior.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Configuration loading and validation in `repos/arashi` (`.arashi/config.json` schema and parsing logic).
+- Worktree creation/orchestration flows that derive destination paths.
+- Repository setup behavior related to ignore rules for default worktree directories.
+- Command and integration tests that verify location resolution and defaults across supported path styles.

--- a/openspec/changes/add-config-option-for-worktrees-locations/specs/configurable-worktree-location/spec.md
+++ b/openspec/changes/add-config-option-for-worktrees-locations/specs/configurable-worktree-location/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Workspace configuration defines worktree base location
+The system SHALL support a workspace configuration field that defines the base directory used for newly created worktrees.
+
+#### Scenario: Explicit configured location is used
+- **WHEN** the workspace config provides a worktree location value
+- **THEN** new worktree paths are created under that configured base directory
+
+#### Scenario: Default location is used when configuration is omitted
+- **WHEN** the workspace config does not provide a worktree location value
+- **THEN** the system MUST use `.arashi/worktrees/` as the default base directory
+
+### Requirement: Relative path inputs are normalized consistently
+The system MUST normalize supported relative path inputs for worktree location, including optional trailing slash variants, before destination paths are used.
+
+#### Scenario: Dot path variants normalize to repository root
+- **WHEN** the configured location is `.` or `./`
+- **THEN** destination resolution treats both values as the same repository-root base path
+
+#### Scenario: Managed directory variants normalize identically
+- **WHEN** the configured location is `.arashi/worktrees` or `.arashi/worktrees/`
+- **THEN** destination resolution treats both values as the same base path
+
+#### Scenario: Parent directory variant remains valid
+- **WHEN** the configured location is `../` (or equivalent trailing-slash form)
+- **THEN** destination resolution uses the workspace parent directory as the base path
+
+### Requirement: Worktree creation uses a single resolved base path
+All commands that create worktrees MUST derive their destination from a shared resolved worktree base path rather than command-specific path logic.
+
+#### Scenario: Worktree-producing commands resolve destinations consistently
+- **WHEN** different commands create worktrees in the same workspace configuration
+- **THEN** each command resolves the same destination base path for equivalent inputs
+
+### Requirement: Default managed worktree directory is git-ignored
+When the default managed worktree location is in use, the system SHALL ensure `.arashi/worktrees/` is ignored by git in an idempotent way.
+
+#### Scenario: Default path adds missing ignore entry
+- **WHEN** the default managed location is active and `.gitignore` lacks `.arashi/worktrees/`
+- **THEN** the system adds `.arashi/worktrees/` to ignore rules without duplicating entries
+
+#### Scenario: Existing ignore entry is preserved without duplication
+- **WHEN** `.gitignore` already includes `.arashi/worktrees/`
+- **THEN** setup and initialization flows complete without adding duplicate ignore lines

--- a/openspec/changes/add-config-option-for-worktrees-locations/tasks.md
+++ b/openspec/changes/add-config-option-for-worktrees-locations/tasks.md
@@ -1,0 +1,28 @@
+## 1. Config Option and Normalization
+
+- [x] 1.1 Add a workspace config field in `repos/arashi/src/lib/config.ts` for the worktree base location and include it in load/save types.
+- [x] 1.2 Implement normalization for configured location inputs (`../`, `.`, `./`, `.arashi/worktrees`, optional trailing slash) into a canonical internal form.
+- [x] 1.3 Apply default fallback behavior so omitted configuration resolves to `.arashi/worktrees/`.
+
+## 2. Shared Worktree Path Resolution
+
+- [x] 2.1 Create a shared path-resolution utility that derives the absolute/normalized destination base from workspace root + configured location.
+- [x] 2.2 Update all worktree-creating command flows in `repos/arashi/src` to use the shared resolver instead of command-specific path logic.
+- [x] 2.3 Ensure equivalent configured inputs resolve to identical destination paths across commands.
+
+## 3. Default Ignore Management
+
+- [x] 3.1 Update init/setup logic to ensure `.arashi/worktrees/` is added to git ignore rules when the default managed location is used.
+- [x] 3.2 Make ignore updates idempotent so existing `.arashi/worktrees/` entries are preserved without duplication.
+- [x] 3.3 Avoid auto-editing ignore rules for non-default custom locations.
+
+## 4. Tests for Requirements Coverage
+
+- [x] 4.1 Add unit tests for config location parsing, normalization, and default fallback behavior.
+- [x] 4.2 Add integration tests verifying worktree destination resolution for `../`, `.`, `./`, `.arashi/worktrees`, and trailing-slash variants.
+- [x] 4.3 Add tests for ignore handling that cover both missing and pre-existing `.arashi/worktrees/` entries.
+
+## 5. Validation and Quality Checks
+
+- [x] 5.1 Run required checks in `repos/arashi`: `bun run lint` and `bun test`.
+- [x] 5.2 Run recommended build check in `repos/arashi`: `bun run build`.


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal/design/spec/tasks artifacts for configurable worktree destination paths.
- Capture completed task tracking so the spec package matches the implemented behavior.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/40, https://github.com/corwinm/arashi-docs/pull/9, https://github.com/corwinm/arashi-skills/pull/8
- Related issue: https://github.com/corwinm/arashi-arashi/issues/113

Closes #113