### PR TITLE
specs: add security-audit remediation change artifacts

### DIFF
--- a/openspec/changes/update-skills-to-pass-security-audits/.openspec.yaml
+++ b/openspec/changes/update-skills-to-pass-security-audits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/update-skills-to-pass-security-audits/design.md
+++ b/openspec/changes/update-skills-to-pass-security-audits/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The SKILLS distribution currently fails external security audits, which blocks trusted adoption and creates release friction. The change spans skill content generation, packaging inputs, and CI/release validation, so the design must ensure audit compliance is repeatable rather than a one-time manual fix.
+
+Constraints:
+- Existing release flow and project conventions should remain intact where possible.
+- Security checks must run deterministically in CI to prevent regressions.
+- Documentation must clearly describe compliance expectations for contributors.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish a deterministic audit-compliance pipeline for SKILLS artifacts before release.
+- Remove or remediate current audit findings in dependencies and packaged outputs.
+- Add guardrails that fail CI/release when new findings are introduced.
+- Align implementation, docs, and contributor workflow around the same security baseline.
+
+**Non-Goals:**
+- Redesigning unrelated SKILLS features or content taxonomy.
+- Introducing a new package/release platform.
+- Providing long-term vulnerability triage automation beyond release-time enforcement.
+
+## Decisions
+
+1. Define a single "security gate" step for SKILLS artifacts in CI and release validation.
+   - Rationale: One canonical gate avoids drift between local checks and release checks.
+   - Alternatives considered:
+     - Multiple ad hoc checks across scripts (rejected: inconsistent pass/fail criteria).
+     - Manual review-only process (rejected: non-repeatable and easy to bypass).
+
+2. Treat both dependency audit results and packaged artifact contents as first-class validation targets.
+   - Rationale: Passing dependency audits alone is insufficient if generated artifacts still include unsafe or unnecessary content.
+   - Alternatives considered:
+     - Dependency-only auditing (rejected: misses artifact-level risks).
+     - Artifact-only scanning (rejected: misses vulnerable transitive dependencies).
+
+3. Scope remediations to minimal-risk updates first (pinning, patch-level upgrades, pruning unused packages), with explicit exceptions documented.
+   - Rationale: Reduces breakage risk while addressing the highest-priority audit failures quickly.
+   - Alternatives considered:
+     - Broad major-version upgrades immediately (rejected: higher compatibility risk).
+     - Ignoring findings via blanket suppressions (rejected: reduces trust and hides risk).
+
+4. Publish contributor guidance describing required checks and remediation workflow.
+   - Rationale: Security compliance must be part of normal development, not tribal knowledge.
+   - Alternatives considered:
+     - CI-only enforcement without docs (rejected: causes avoidable contributor friction).
+
+## Risks / Trade-offs
+
+- [Risk] Audit tool output may change over time and create flaky failures -> Mitigation: pin tool/runtime versions where possible and normalize check inputs.
+- [Risk] Dependency updates can introduce functional regressions -> Mitigation: keep upgrades incremental and require existing test/build checks before merge.
+- [Risk] Strict gating can temporarily slow contributor velocity -> Mitigation: provide clear remediation playbook and fast local validation commands.
+- [Risk] Some findings may not be immediately fixable upstream -> Mitigation: allow time-bounded, documented exceptions with owner and expiration.
+
+## Migration Plan
+
+1. Baseline current audit findings for SKILLS dependencies and produced artifacts.
+2. Apply minimal-risk remediations and verify existing lint/test/build checks still pass.
+3. Add the security gate to CI/release workflows in non-blocking mode briefly (optional) to validate signal quality.
+4. Switch gate to blocking mode and require pass status for merge/release.
+5. Update contributor documentation and release notes to reflect the new policy.
+
+Rollback strategy:
+- If blocking mode causes widespread false positives, temporarily revert to non-blocking while preserving audit visibility, then re-enable after rule adjustment.
+
+## Open Questions
+
+- Which exact audit command and threshold should be canonical for SKILLS in this repository?
+- Do we need separate policies for development vs release artifact checks?
+- Are any current findings acceptable as temporary exceptions, and who owns their remediation deadlines?

--- a/openspec/changes/update-skills-to-pass-security-audits/proposal.md
+++ b/openspec/changes/update-skills-to-pass-security-audits/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The published SKILLS package currently fails security audits, which blocks reliable distribution and raises risk for users consuming the artifacts. We need to close known audit findings now so release and install workflows remain trusted and unblocked.
+
+## What Changes
+
+- Update SKILLS package and related build/release inputs to remove or remediate security audit findings.
+- Tighten dependency and artifact hygiene for skill assets so generated outputs do not include insecure or unnecessary content.
+- Add or improve validation checks in CI/release flow to fail fast when security audit regressions are introduced.
+- Update contributor guidance for maintaining audit-compliant SKILLS artifacts.
+
+## Capabilities
+
+### New Capabilities
+- `skills-security-audit-compliance`: Define requirements for producing and validating SKILLS artifacts that pass security audits before release.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected repositories and paths related to SKILLS definitions, packaging scripts, and release/CI validation.
+- Potential updates to dependency declarations, lockfiles, and generated skill artifact contents.
+- Developer workflow impact: contributors must satisfy security audit checks before merging and releasing SKILLS updates.

--- a/openspec/changes/update-skills-to-pass-security-audits/specs/skills-security-audit-compliance/spec.md
+++ b/openspec/changes/update-skills-to-pass-security-audits/specs/skills-security-audit-compliance/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Security Gate Blocks Non-Compliant Releases
+The SKILLS build and release workflow SHALL execute a canonical security audit gate before a release artifact is published. The workflow MUST fail and block publication when the gate reports unresolved findings above the configured policy threshold.
+
+#### Scenario: Release is blocked on failing audit gate
+- **WHEN** a release workflow run evaluates SKILLS artifacts and the audit gate reports policy-violating findings
+- **THEN** the workflow fails before publishing artifacts and records the failed gate result in job output
+
+### Requirement: Dependency Findings Are Remediated or Explicitly Excepted
+The SKILLS project SHALL remediate dependency vulnerabilities identified by the canonical audit process before release. If a finding cannot be remediated immediately, the project MUST record a time-bounded exception with owner, rationale, and expiration, and the gate MUST enforce that expired exceptions fail validation.
+
+#### Scenario: Expired exception fails validation
+- **WHEN** the security gate evaluates findings that are covered only by an exception past its expiration date
+- **THEN** the gate fails with a message identifying the expired exception and required remediation owner
+
+### Requirement: Packaged Skill Artifacts Meet Content Hygiene Rules
+Generated and packaged SKILLS artifacts SHALL be validated for content hygiene as part of the same security gate. The validation MUST confirm that packaged outputs exclude disallowed files or insecure payload content defined by repository policy.
+
+#### Scenario: Artifact includes disallowed content
+- **WHEN** artifact validation detects a file or payload pattern that is disallowed by SKILLS packaging policy
+- **THEN** the security gate fails and reports the disallowed content location for remediation
+
+### Requirement: Contributors Have a Documented Security Compliance Workflow
+The repository SHALL provide contributor-facing guidance that defines required local and CI checks for SKILLS security compliance, including remediation expectations and exception policy. The documented workflow MUST match the canonical gate used by CI and release pipelines.
+
+#### Scenario: Contributor follows documented checks before PR
+- **WHEN** a contributor runs the documented compliance steps before opening a pull request
+- **THEN** the same class of audit failures enforced in CI is detected locally with actionable remediation guidance

--- a/openspec/changes/update-skills-to-pass-security-audits/tasks.md
+++ b/openspec/changes/update-skills-to-pass-security-audits/tasks.md
@@ -1,0 +1,23 @@
+## 1. Baseline and Policy Definition
+
+- [x] 1.1 Inventory current SKILLS dependency and artifact audit findings, then document the baseline failure set.
+- [x] 1.2 Define the canonical security gate command(s), severity threshold, and pass/fail policy for CI and release workflows.
+- [x] 1.3 Define exception metadata requirements (owner, rationale, expiration) and failure behavior for expired exceptions.
+
+## 2. Remediation and Packaging Hygiene
+
+- [x] 2.1 Apply minimal-risk dependency remediations (pinning, patch updates, pruning unused packages) to eliminate baseline findings.
+- [x] 2.2 Implement artifact content hygiene checks to detect disallowed files or insecure payload patterns in packaged outputs.
+- [x] 2.3 Add a machine-readable exception mechanism and validation logic that rejects expired or malformed exceptions.
+
+## 3. CI and Release Gate Enforcement
+
+- [x] 3.1 Integrate the canonical security gate into CI pull request validation with clear failure output.
+- [x] 3.2 Integrate the same gate into release workflows so artifact publication is blocked on audit policy violations.
+- [x] 3.3 Ensure gate output reports dependency findings, artifact hygiene violations, and exception failures with actionable details.
+
+## 4. Documentation and Verification
+
+- [x] 4.1 Update contributor docs with required local and CI security compliance checks and remediation workflow.
+- [x] 4.2 Add guidance for requesting and managing time-bounded exceptions, including ownership and expiry expectations.
+- [x] 4.3 Verify end-to-end behavior with failing and passing test cases to confirm release blocking, exception expiry enforcement, and contributor guidance alignment.


### PR DESCRIPTION
## Summary
- Add a full OpenSpec change for SKILLS security-audit remediation (`proposal`, `design`, capability spec, and implementation tasks).
- Define requirements for a canonical security gate, exception handling, artifact hygiene, and contributor workflow expectations.
- Provide implementation-ready task breakdown for the companion repository work.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-skills/pull/10
- Related issue: https://github.com/corwinm/arashi-arashi/issues/110

Closes #110