### PR TITLE
specs: stop requiring .gitignore worktree mutation

### DIFF
--- a/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-24

--- a/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/design.md
+++ b/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Current setup/init flows treat `.arashi/worktrees/` as a path that must be explicitly added to `.gitignore` when default worktree location is used. For this repository behavior, that write is unnecessary and produces avoidable diffs in user-owned ignore files. The change is intentionally narrow: remove automatic `.gitignore` mutation while preserving existing worktree path resolution and command behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate automatic `.gitignore` writes for `.arashi/worktrees/`.
+- Keep setup/init/create flows functional with default and configured worktree locations.
+- Keep behavior idempotent and side-effect-free regarding existing `.gitignore` files.
+- Update tests to assert no `.gitignore` mutation for this case.
+
+**Non-Goals:**
+- Changing default worktree location semantics.
+- Removing or rewriting user-provided `.gitignore` entries.
+- Introducing new CLI flags or configuration fields.
+
+## Decisions
+
+- Remove invocation of helper logic that appends `.arashi/worktrees/` to `.gitignore` during initialization/setup paths.
+  - **Rationale:** Align behavior with Git worktree handling and avoid mutating user files.
+  - **Alternative considered:** Keep current write but gate it behind file-content checks. Rejected because the write remains unnecessary and still couples setup to ignore-file mutation.
+
+- Retain all existing worktree path resolution logic and only alter ignore-file side effects.
+  - **Rationale:** Limits blast radius and reduces regression risk in worktree creation.
+  - **Alternative considered:** Refactor worktree destination and ignore behavior together. Rejected because issue scope is specific and does not require broader path changes.
+
+- Adjust tests to verify `.gitignore` remains unchanged for default managed path.
+  - **Rationale:** Ensures regressions are caught if ignore-file mutation is reintroduced.
+  - **Alternative considered:** Remove tests for ignore handling entirely. Rejected because the new behavior is contractually important.
+
+## Risks / Trade-offs
+
+- [Risk] Existing tests may assume `.gitignore` is created or modified as part of setup. -> Mitigation: update assertions to validate no mutation and preserve other setup side effects.
+- [Risk] Some user workflows may have relied on auto-added ignore line for visibility. -> Mitigation: preserve any pre-existing ignore entries and document that Arashi no longer edits `.gitignore` for worktree path.
+- [Trade-off] Less automated repository mutation means users own ignore configuration decisions. -> Mitigation: keep docs explicit about default worktree location and expected Git behavior.
+
+## Migration Plan
+
+1. Update setup/init implementation to stop writing `.arashi/worktrees/` into `.gitignore`.
+2. Update relevant unit/integration tests to assert `.gitignore` is unchanged.
+3. Update docs/spec deltas to reflect the new contract.
+4. Validate with lint, test, and build before merge.
+
+Rollback strategy: restore previous ignore-update call sites and test expectations if regressions appear.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/proposal.md
+++ b/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Arashi currently appends `.arashi/worktrees/` to `.gitignore` when the default managed worktree location is used. Git already excludes worktree administrative paths via built-in behavior, so mutating user `.gitignore` files is redundant and creates unnecessary repository noise.
+
+## What Changes
+
+- Stop automatically adding `.arashi/worktrees/` to `.gitignore` during setup/init flows.
+- Preserve existing `.gitignore` contents exactly as authored by the user.
+- Update behavior documentation and tests so default worktree-location setup no longer expects `.gitignore` modification.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `configurable-worktree-location`: remove the requirement that default managed worktree location must be written to `.gitignore`, and require setup/init to avoid modifying ignore files for this path.
+
+## Impact
+
+- Affected specs: `openspec/specs/configurable-worktree-location/spec.md` (via delta).
+- Affected implementation area: initialization/setup config flows in `repos/arashi/` that currently update `.gitignore`.
+- Affected tests: integration/unit coverage asserting `.gitignore` mutation for default worktree location.
+- No API or CLI flag changes; behavior change is limited to filesystem side effects.

--- a/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/specs/configurable-worktree-location/spec.md
+++ b/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/specs/configurable-worktree-location/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Default managed worktree location avoids ignore file mutation
+When the default managed worktree location is in use, setup and initialization flows SHALL NOT modify `.gitignore` solely to add `.arashi/worktrees/`.
+
+#### Scenario: Default path leaves missing ignore entry untouched
+- **WHEN** the default managed location is active and `.gitignore` does not include `.arashi/worktrees/`
+- **THEN** setup and initialization complete without adding `.arashi/worktrees/` to `.gitignore`
+
+#### Scenario: Existing ignore entry is preserved without rewrite
+- **WHEN** `.gitignore` already includes `.arashi/worktrees/`
+- **THEN** setup and initialization complete without modifying existing ignore file contents
+
+## REMOVED Requirements
+
+### Requirement: Default managed worktree directory is git-ignored
+**Reason**: Git worktree handling already avoids tracking worktree administrative paths, so forcing `.gitignore` updates is redundant and creates unnecessary repository diffs.
+**Migration**: Remove test and workflow assumptions that Arashi inserts `.arashi/worktrees/` into `.gitignore`; existing user-authored ignore entries remain valid but optional.

--- a/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/tasks.md
+++ b/openspec/changes/archive/2026-02-23-dont-modify-gitignore-worktrees-location/tasks.md
@@ -1,0 +1,14 @@
+## 1. Remove `.gitignore` mutation behavior
+
+- [x] 1.1 Locate and remove setup/init code paths in `repos/arashi/` that append `.arashi/worktrees/` to `.gitignore`.
+- [x] 1.2 Ensure default and configured worktree location flows still resolve and create worktrees correctly after the removal.
+
+## 2. Update and expand automated coverage
+
+- [x] 2.1 Update existing tests that currently expect `.gitignore` to be modified for default worktree location.
+- [x] 2.2 Add/adjust integration coverage to verify setup/init leaves `.gitignore` unchanged whether the entry is absent or already present.
+
+## 3. Validate and document behavior
+
+- [x] 3.1 Update user-facing docs in `repos/arashi/` (and companion docs repos if needed) to state that Arashi does not auto-edit `.gitignore` for worktree paths.
+- [x] 3.2 Run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi/` and fix any regressions before opening PR.

--- a/openspec/specs/configurable-worktree-location/spec.md
+++ b/openspec/specs/configurable-worktree-location/spec.md
@@ -36,14 +36,13 @@ All commands that create worktrees MUST derive their destination from a shared r
 - **WHEN** different commands create worktrees in the same workspace configuration
 - **THEN** each command resolves the same destination base path for equivalent inputs
 
-### Requirement: Default managed worktree directory is git-ignored
-When the default managed worktree location is in use, the system SHALL ensure `.arashi/worktrees/` is ignored by git in an idempotent way.
+### Requirement: Default managed worktree location avoids ignore file mutation
+When the default managed worktree location is in use, setup and initialization flows SHALL NOT modify `.gitignore` solely to add `.arashi/worktrees/`.
 
-#### Scenario: Default path adds missing ignore entry
-- **WHEN** the default managed location is active and `.gitignore` lacks `.arashi/worktrees/`
-- **THEN** the system adds `.arashi/worktrees/` to ignore rules without duplicating entries
+#### Scenario: Default path leaves missing ignore entry untouched
+- **WHEN** the default managed location is active and `.gitignore` does not include `.arashi/worktrees/`
+- **THEN** setup and initialization complete without adding `.arashi/worktrees/` to `.gitignore`
 
-#### Scenario: Existing ignore entry is preserved without duplication
+#### Scenario: Existing ignore entry is preserved without rewrite
 - **WHEN** `.gitignore` already includes `.arashi/worktrees/`
-- **THEN** setup and initialization flows complete without adding duplicate ignore lines
-
+- **THEN** setup and initialization complete without modifying existing ignore file contents


### PR DESCRIPTION
## Summary
- Archive the completed `dont-modify-gitignore-worktrees-location` change.
- Sync `configurable-worktree-location` spec to require that init/setup do not auto-mutate `.gitignore` for `.arashi/worktrees/`.
- Keep the capability contract aligned with implementation and docs changes in companion repos.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/43, https://github.com/corwinm/arashi-docs/pull/12, https://github.com/corwinm/arashi-skills/pull/12
- Related issue: https://github.com/corwinm/arashi-arashi/issues/120

Closes #120