### PR TITLE
specs: archive revert-ignore-removal and sync worktree ignore requirements

### DIFF
--- a/openspec/changes/archive/2026-02-24-revert-ignore-removal/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-24-revert-ignore-removal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-24

--- a/openspec/changes/archive/2026-02-24-revert-ignore-removal/design.md
+++ b/openspec/changes/archive/2026-02-24-revert-ignore-removal/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`arashi init` currently updates `.gitignore` for `repos/` and only adds a worktree ignore entry when the configured worktree location is the default `.arashi/worktrees/`. After the recent change, custom managed worktree locations are no longer reflected in `.gitignore`, so initialized workspaces can accumulate noisy untracked directories.
+
+This change restores ignore synchronization while preserving the original constraints around idempotency and path normalization.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore `.gitignore` updates for the active managed worktree location when safe to express as a repository-relative directory pattern.
+- Keep ignore updates idempotent and normalization-aware (trailing slash variants map to one canonical entry).
+- Keep `init` output and dry-run output aligned with the actual patterns that will be managed.
+
+**Non-Goals:**
+- Changing how worktree destination paths are resolved or validated.
+- Adding support for absolute worktree paths (still invalid).
+- Automatically rewriting existing user-authored `.gitignore` sections beyond appending missing managed patterns.
+
+## Decisions
+
+1. Restore configured worktree ignore pattern calculation
+   - Decision: derive a candidate ignore pattern from normalized `worktreesDir`, then include it in managed patterns when safe.
+   - Rationale: this directly reverts the behavior loss while keeping pattern management centralized in init gitignore logic.
+   - Alternatives considered:
+     - Keep default-only behavior: rejected because it does not restore requested functionality.
+     - Hard-code all non-default values: rejected because some values (for example `.`) are unsafe to auto-ignore.
+
+2. Apply safety guardrails for broad or out-of-repo locations
+   - Decision: skip automatic worktree ignore insertion when the configured location resolves to repo root (`.`/`./`) or parent traversal (`../` variants).
+   - Rationale: adding these patterns can ignore unrelated files or be ineffective and confusing.
+   - Alternatives considered:
+     - Always write configured value to `.gitignore`: rejected due to risk of broad accidental ignores.
+
+3. Keep behavior observable and testable
+   - Decision: update integration tests for custom worktree directory cases and keep dry-run/success messaging synchronized with managed patterns.
+   - Rationale: regression risk is in init flow behavior, so integration coverage is the most direct guard.
+
+## Risks / Trade-offs
+
+- [Risk] Users may expect every custom value to be auto-ignored, including unsafe values. -> Mitigation: document skip behavior in tests and output.
+- [Risk] Pattern normalization drift between config and ignore helper could create duplicate variants. -> Mitigation: reuse existing normalization helpers and idempotent pattern detection.
+- [Trade-off] Safety filters mean some valid advanced layouts still require manual `.gitignore` updates. -> Mitigation: preserve explicit user control for non-standard layouts.
+
+## Migration Plan
+
+1. Update init gitignore pattern selection to include safe configured worktree location entries.
+2. Update integration tests to assert restored custom-location ignore behavior and safety skips.
+3. Validate with `bun run lint`, `bun test`, and `bun run build` in `repos/arashi`.
+
+Rollback: revert the pattern-selection logic and associated test expectations.
+
+## Open Questions
+
+- None; this is a behavior restoration with scoped safety constraints.

--- a/openspec/changes/archive/2026-02-24-revert-ignore-removal/proposal.md
+++ b/openspec/changes/archive/2026-02-24-revert-ignore-removal/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Recent behavior no longer updates `.gitignore` with the configured worktree location. This causes managed worktree directories to appear as untracked files and reintroduces repository noise for initialized workspaces.
+
+## What Changes
+
+- Restore `.gitignore` updates so initialization adds the active worktree location ignore entry, not only the managed repos path.
+- Preserve idempotent ignore behavior so repeated init/setup flows do not duplicate existing entries.
+- Keep path normalization consistent so equivalent worktree location variants produce one stable ignore pattern.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `configurable-worktree-location`: Update ignore requirements so `.gitignore` tracks the configured managed worktree location entry in an idempotent, normalized way.
+
+## Impact
+
+- Affected spec: `openspec/specs/configurable-worktree-location/spec.md`
+- Affected code: `repos/arashi/src/commands/init.ts` (gitignore pattern selection and output)
+- Affected tests: `repos/arashi/tests/integration/init.test.ts` (custom worktree directory ignore behavior)

--- a/openspec/changes/archive/2026-02-24-revert-ignore-removal/specs/configurable-worktree-location/spec.md
+++ b/openspec/changes/archive/2026-02-24-revert-ignore-removal/specs/configurable-worktree-location/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Default managed worktree directory is git-ignored
+The system SHALL ensure the active managed worktree location is ignored by git in an idempotent way when that location is a safe repository-relative directory pattern.
+
+#### Scenario: Default path adds missing ignore entry
+- **WHEN** the default managed location is active and `.gitignore` lacks `.arashi/worktrees/`
+- **THEN** the system adds `.arashi/worktrees/` to ignore rules without duplicating entries
+
+#### Scenario: Configured managed subdirectory adds missing ignore entry
+- **WHEN** a non-default worktree location is configured as a repository-relative subdirectory and `.gitignore` lacks its normalized trailing-slash entry
+- **THEN** the system adds the normalized configured worktree directory entry without duplicating entries
+
+#### Scenario: Existing configured ignore entry is preserved without duplication
+- **WHEN** `.gitignore` already includes the normalized active worktree location entry
+- **THEN** setup and initialization flows complete without adding duplicate ignore lines
+
+#### Scenario: Unsafe broad locations are not auto-ignored
+- **WHEN** the configured worktree location resolves to repository root (`.`/`./`) or parent traversal (`../` variants)
+- **THEN** setup and initialization flows do not auto-add a worktree-location ignore pattern

--- a/openspec/changes/archive/2026-02-24-revert-ignore-removal/tasks.md
+++ b/openspec/changes/archive/2026-02-24-revert-ignore-removal/tasks.md
@@ -1,0 +1,17 @@
+## 1. Restore worktree ignore pattern selection
+
+- [x] 1.1 Update init command gitignore pattern selection to include a normalized configured worktrees directory entry when it is a safe repository-relative subdirectory.
+- [x] 1.2 Add guardrails that skip automatic worktree ignore insertion for broad locations (`.`/`./`) and parent traversal (`../` variants).
+- [x] 1.3 Keep dry-run and success output aligned with the actual managed gitignore patterns.
+
+## 2. Cover restored behavior with tests
+
+- [x] 2.1 Update init integration tests to expect configured safe custom worktree directory entries in `.gitignore`.
+- [x] 2.2 Add/adjust integration tests to verify no auto-ignore entry is added for unsafe broad locations.
+- [x] 2.3 Keep idempotency assertions valid for both default and configured worktree ignore entries.
+
+## 3. Validate and finalize
+
+- [x] 3.1 Run `bun run lint` in `repos/arashi` and resolve any issues.
+- [x] 3.2 Run `bun test` in `repos/arashi` and ensure all affected init scenarios pass.
+- [x] 3.3 Run `bun run build` in `repos/arashi` to confirm distributable build health.

--- a/openspec/specs/configurable-worktree-location/spec.md
+++ b/openspec/specs/configurable-worktree-location/spec.md
@@ -37,13 +37,20 @@ All commands that create worktrees MUST derive their destination from a shared r
 - **THEN** each command resolves the same destination base path for equivalent inputs
 
 ### Requirement: Default managed worktree directory is git-ignored
-When the default managed worktree location is in use, the system SHALL ensure `.arashi/worktrees/` is ignored by git in an idempotent way.
+The system SHALL ensure the active managed worktree location is ignored by git in an idempotent way when that location is a safe repository-relative directory pattern.
 
 #### Scenario: Default path adds missing ignore entry
 - **WHEN** the default managed location is active and `.gitignore` lacks `.arashi/worktrees/`
 - **THEN** the system adds `.arashi/worktrees/` to ignore rules without duplicating entries
 
-#### Scenario: Existing ignore entry is preserved without duplication
-- **WHEN** `.gitignore` already includes `.arashi/worktrees/`
+#### Scenario: Configured managed subdirectory adds missing ignore entry
+- **WHEN** a non-default worktree location is configured as a repository-relative subdirectory and `.gitignore` lacks its normalized trailing-slash entry
+- **THEN** the system adds the normalized configured worktree directory entry without duplicating entries
+
+#### Scenario: Existing configured ignore entry is preserved without duplication
+- **WHEN** `.gitignore` already includes the normalized active worktree location entry
 - **THEN** setup and initialization flows complete without adding duplicate ignore lines
 
+#### Scenario: Unsafe broad locations are not auto-ignored
+- **WHEN** the configured worktree location resolves to repository root (`.`/`./`) or parent traversal (`../` variants)
+- **THEN** setup and initialization flows do not auto-add a worktree-location ignore pattern


### PR DESCRIPTION
## Summary
- Sync `configurable-worktree-location` requirements to restore managed worktree ignore behavior for safe custom paths.
- Archive completed OpenSpec change artifacts for `revert-ignore-removal`.
- Keep archive/spec artifacts aligned for implementation traceability.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/44, https://github.com/corwinm/arashi-docs/pull/13, https://github.com/corwinm/arashi-skills/pull/13
- Related issue: https://github.com/corwinm/arashi-arashi/issues/120
- Closes #120