### PR TITLE
specs: restore managed worktree gitignore requirements

### DIFF
--- a/openspec/specs/configurable-worktree-location/spec.md
+++ b/openspec/specs/configurable-worktree-location/spec.md
@@ -36,13 +36,21 @@ All commands that create worktrees MUST derive their destination from a shared r
 - **WHEN** different commands create worktrees in the same workspace configuration
 - **THEN** each command resolves the same destination base path for equivalent inputs
 
-### Requirement: Default managed worktree location avoids ignore file mutation
-When the default managed worktree location is in use, setup and initialization flows SHALL NOT modify `.gitignore` solely to add `.arashi/worktrees/`.
+### Requirement: Default managed worktree directory is git-ignored
+The system SHALL ensure the active managed worktree location is ignored by git in an idempotent way when that location is a safe repository-relative directory pattern.
 
-#### Scenario: Default path leaves missing ignore entry untouched
-- **WHEN** the default managed location is active and `.gitignore` does not include `.arashi/worktrees/`
-- **THEN** setup and initialization complete without adding `.arashi/worktrees/` to `.gitignore`
+#### Scenario: Default path adds missing ignore entry
+- **WHEN** the default managed location is active and `.gitignore` lacks `.arashi/worktrees/`
+- **THEN** the system adds `.arashi/worktrees/` to ignore rules without duplicating entries
 
-#### Scenario: Existing ignore entry is preserved without rewrite
-- **WHEN** `.gitignore` already includes `.arashi/worktrees/`
-- **THEN** setup and initialization complete without modifying existing ignore file contents
+#### Scenario: Configured managed subdirectory adds missing ignore entry
+- **WHEN** a non-default worktree location is configured as a repository-relative subdirectory and `.gitignore` lacks its normalized trailing-slash entry
+- **THEN** the system adds the normalized configured worktree directory entry without duplicating entries
+
+#### Scenario: Existing configured ignore entry is preserved without duplication
+- **WHEN** `.gitignore` already includes the normalized active worktree location entry
+- **THEN** setup and initialization flows complete without adding duplicate ignore lines
+
+#### Scenario: Unsafe broad locations are not auto-ignored
+- **WHEN** the configured worktree location resolves to repository root (`.`/`./`) or parent traversal (`../` variants)
+- **THEN** setup and initialization flows do not auto-add a worktree-location ignore pattern


### PR DESCRIPTION
## Summary
- Revert the no-mutation requirement for managed worktree ignore behavior.
- Restore spec language so default and safe custom managed worktree locations are git-ignored.
- Keep guardrails for broad locations (`.` and `../` variants).

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/45, https://github.com/corwinm/arashi-docs/pull/14, https://github.com/corwinm/arashi-skills/pull/14
- Related issue: https://github.com/corwinm/arashi-arashi/issues/120
- Closes #120