### PR TITLE
specs: define remediation artifacts for skill security issue

### DIFF
--- a/openspec/changes/fix-skills-security-issues/.openspec.yaml
+++ b/openspec/changes/fix-skills-security-issues/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/fix-skills-security-issues/design.md
+++ b/openspec/changes/fix-skills-security-issues/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Issue #124 identifies repeated security findings in `arashi-skills` documentation and skill artifacts: unverifiable remote script execution (`curl | bash`), privileged install steps, dynamic execution of downloaded binaries/hooks without integrity checks, and unsafe shell substitution patterns. The repository already has a security-compliance capability, but current requirements do not explicitly prohibit these documentation patterns, so scanner findings can recur even when CI passes unrelated checks.
+
+Constraints:
+- Keep guidance practical for contributors across macOS and Linux shells.
+- Prefer low-friction, auditable installation paths over bespoke bootstrap scripts.
+- Changes must remain compatible with existing skill packaging and release workflows.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define explicit requirements for safe installation and command examples in skill docs.
+- Eliminate high-risk guidance patterns that trigger security scanners.
+- Require verifiable provenance/integrity checks before executing downloaded artifacts.
+- Ensure metadata versioning is updated when security guidance changes are released.
+
+**Non-Goals:**
+- Re-architecting Arashi CLI distribution infrastructure.
+- Building a new signed-update framework in this change.
+- Refactoring unrelated skill content outside security-sensitive guidance.
+
+## Decisions
+
+1. Add normative spec requirements under `skills-security-audit-compliance` for install-command safety and shell-command hygiene.
+   - Rationale: This keeps security expectations enforceable and testable at the requirements layer rather than as ad hoc reviewer preference.
+   - Alternatives considered:
+     - Only patching docs without spec updates (rejected: high regression risk).
+     - Creating a separate capability for docs hygiene (rejected: unnecessary fragmentation for tightly related behavior).
+
+2. Replace remote-script execution guidance with verifiable distribution methods (trusted package manager or release artifact verification workflow).
+   - Rationale: Avoids direct runtime execution of untrusted network content.
+   - Alternatives considered:
+     - Keep `curl | bash` with warning text (rejected: still unacceptable risk pattern).
+     - Keep custom installer but add optional checksum section (rejected: primary path would remain unsafe).
+
+3. Require least-privilege examples and safe command composition in docs.
+   - Rationale: Security scanners and users both treat documentation as executable policy; examples must avoid normalizing unsafe practices.
+   - Alternatives considered:
+     - Allow `sudo` and command substitution with disclaimers (rejected: scanners still flag and users may copy insecure defaults).
+
+## Risks / Trade-offs
+
+- [Risk] Safer install guidance may be longer than one-line bootstrap commands -> Mitigation: provide concise, copy-pasteable verified examples.
+- [Risk] Some users rely on existing installer docs -> Mitigation: include migration notes in docs and keep fallback options explicit and verified.
+- [Risk] Scanner rule differences can produce new false positives -> Mitigation: codify prohibited patterns in specs and align docs to deterministic examples.
+
+## Migration Plan
+
+1. Update `arashi-skills` skill docs and references to remove flagged install and command patterns.
+2. Add/adjust examples to use verified installation and safe shell handling.
+3. Update skill version metadata to publish the remediated guidance.
+4. Run project lint/test/build and applicable security checks before merge.
+
+Rollback strategy:
+- Revert documentation and version changes if critical usability issues emerge, then re-issue with revised verified examples while preserving the no-`curl | bash` policy.
+
+## Open Questions
+
+- Which single verification method should be the canonical default (checksum-only, signature-only, or both) for release artifacts?
+- Should CI add explicit pattern checks for prohibited install snippets in documentation files?

--- a/openspec/changes/fix-skills-security-issues/proposal.md
+++ b/openspec/changes/fix-skills-security-issues/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Security scanners are flagging the `arashi` skill documentation for unsafe installation and command patterns, which undermines user trust and blocks clean security reports for release. We need to remediate these findings now so the published skill guidance is auditable, least-privilege, and aligned with secure supply-chain practices.
+
+## What Changes
+
+- Remove or replace high-risk install instructions that execute remote scripts directly (for example `curl | bash`) with verifiable installation guidance.
+- Replace privileged install steps (`sudo mv` into system paths) with safer user-scoped alternatives and explicit trust boundaries.
+- Update command examples that execute dynamic, unsanitized shell substitutions to safer patterns that reduce injection risk from untrusted repository names.
+- Add integrity and provenance expectations for downloaded binaries and executable hooks in skill guidance.
+- Update `arashi-skills` skill version metadata after the security remediations are complete.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `skills-security-audit-compliance`: Extend requirements so skill documentation and packaged guidance avoid unverifiable remote execution, unnecessary privilege escalation, and unsafe dynamic command composition.
+
+## Impact
+
+- Affected repo: `repos/arashi-skills` (skill manifests and reference documentation for installation and command usage).
+- Potential updates to documentation examples, release/packaging validation inputs, and skill metadata versioning.
+- Contributors will follow stricter documentation hygiene rules for install commands, binary verification, and shell safety.

--- a/openspec/changes/fix-skills-security-issues/specs/skills-security-audit-compliance/spec.md
+++ b/openspec/changes/fix-skills-security-issues/specs/skills-security-audit-compliance/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Installation Guidance Uses Verifiable Distribution Paths
+SKILLS documentation and generated skill references SHALL provide installation workflows that avoid direct execution of remote script content from network responses. Installation guidance MUST use verifiable distribution paths, including trusted package manager commands or release artifact download flows that include integrity verification steps before execution.
+
+#### Scenario: Documentation install path is scanner-safe
+- **WHEN** a contributor or user follows the documented installation commands for the Arashi skill
+- **THEN** the commands do not include pipe-to-shell patterns and include a verifiable source or integrity-check step for downloaded artifacts
+
+### Requirement: Documentation Enforces Least-Privilege Installation
+Skill documentation SHALL present least-privilege installation commands as the default path. Documentation MUST NOT require privileged operations such as `sudo mv` into system directories for standard usage, and any privileged workflow MUST be explicitly isolated as optional with clear risk/trust guidance.
+
+#### Scenario: Default install avoids privileged file moves
+- **WHEN** a user follows the default installation instructions from skill references
+- **THEN** the workflow installs and runs the tool without requiring administrative file moves into global system paths
+
+### Requirement: Shell Examples Avoid Unsanitized Dynamic Composition
+Skill command examples SHALL avoid unsanitized command substitution or argument interpolation sourced from untrusted repository metadata. Examples MUST use quoted variables, explicit selection steps, or equivalent safe composition patterns that prevent unintended command execution from malicious names.
+
+#### Scenario: Repository selection example is injection-resistant
+- **WHEN** documentation shows a command workflow that selects a repository or worktree from local listings
+- **THEN** the example avoids unsafe inline substitution patterns and preserves shell-safe argument handling for selected values
+
+### Requirement: Executable Artifact Guidance Includes Integrity Expectations
+Any documentation step that downloads binaries, hook scripts, or other executable artifacts SHALL include integrity or provenance verification guidance before local execution. Guidance MUST define the expected trusted source and verification action so contributors can detect tampering.
+
+#### Scenario: Downloaded executable is verified before run
+- **WHEN** a documented workflow requires downloading an executable artifact
+- **THEN** the workflow includes an integrity/provenance verification step and executes only after successful verification

--- a/openspec/changes/fix-skills-security-issues/tasks.md
+++ b/openspec/changes/fix-skills-security-issues/tasks.md
@@ -1,0 +1,17 @@
+## 1. Replace Unverifiable Installation Guidance
+
+- [x] 1.1 Audit `repos/arashi-skills/arashi/SKILL.md` and security-flagged reference docs to locate every `curl | bash` and similar remote-script execution pattern.
+- [x] 1.2 Replace unsafe installation examples with verifiable distribution workflows (trusted package manager and/or verified release artifact download path).
+- [x] 1.3 Update documentation text to require integrity/provenance checks before executing downloaded binaries or lifecycle hook scripts.
+
+## 2. Enforce Least Privilege and Shell-Safe Examples
+
+- [x] 2.1 Remove default privileged install steps (for example `sudo mv` to system paths) and provide user-scoped alternatives as the primary guidance.
+- [x] 2.2 Revise repository/worktree selection examples to avoid unsanitized command substitution and use shell-safe argument handling.
+- [x] 2.3 Add concise risk/trust notes where optional privileged or advanced workflows remain necessary.
+
+## 3. Versioning and Verification
+
+- [x] 3.1 Bump `arashi` skill version metadata in `repos/arashi-skills` to reflect the security guidance update.
+- [x] 3.2 Run repository validation (lint/tests and any security scanners used by SKILLS checks) and address regressions.
+- [x] 3.3 Verify scanner-reported findings from issue #124 are remediated, then capture results for PR description and cross-repo references if companion docs/spec PRs are needed.


### PR DESCRIPTION
## Summary
- Add the `fix-skills-security-issues` OpenSpec change with proposal, design, specs delta, and tasks.
- Define requirements for safer install guidance, least-privilege docs, and shell-safe command examples.
- Prepare implementation planning artifacts for issue #124 so follow-on repo changes stay aligned.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-skills/pull/15
- Related issue: https://github.com/corwinm/arashi-arashi/issues/124

Closes #124