### PR TITLE
specs: define docs value-prop animation change

### DIFF
--- a/openspec/changes/explain-arashi-value/.openspec.yaml
+++ b/openspec/changes/explain-arashi-value/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/explain-arashi-value/design.md
+++ b/openspec/changes/explain-arashi-value/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Arashi's documentation currently explains commands, but first-time readers do not quickly understand the outcome: coordinating parallel work across multiple repositories and worktrees. The proposal defines a docs-and-README update focused on value communication, especially for a frontend+backend scenario where users switch focus while another worktree stays active.
+
+This change is content and presentation only (no CLI behavior changes), but it is cross-cutting across `repos/arashi-docs/` (landing page narrative + visuals) and `repos/arashi/README.md` (onboarding narrative + visuals).
+
+Constraints:
+- Keep the example minimal, concrete, and command-accurate.
+- Preserve docs site performance and accessibility (including reduced-motion behavior).
+- Keep messaging consistent between landing page and README.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Communicate the value proposition in the landing page above-the-fold area: "manage multiple repos and multiple worktrees in parallel without losing context."
+- Show a single minimal workflow from setup to switching focus across frontend and backend repos.
+- Provide an animated walkthrough on the landing page that visually reinforces the workflow.
+- Mirror the same narrative in CLI README content so docs and repo onboarding tell the same story.
+
+**Non-Goals:**
+- Changing command behavior, flags, or configuration format.
+- Creating a full tutorial covering every command permutation.
+- Adding external analytics, tracking, or runtime dependencies.
+
+## Decisions
+
+1) Value-first landing section with scenario framing
+- Decision: Rework landing content to lead with the outcome (parallel multi-repo workflow) before feature-level details.
+- Rationale: Users decide quickly whether a tool is for them; outcome language reduces time-to-understanding.
+- Alternatives considered:
+  - Feature list first: easier to write but does not communicate workflow value quickly.
+  - Command reference first: accurate but too implementation-centric for first contact.
+
+2) Canonical minimal example: frontend + backend repos with parallel worktrees
+- Decision: Use one concrete scenario throughout docs and README with explicit setup tree and short command sequence (`add` -> `create` -> `switch`).
+- Rationale: A single repeated example builds comprehension and avoids cognitive overload from multiple disconnected examples.
+- Alternatives considered:
+  - Multiple domain-specific examples: richer but dilutes the core value proposition.
+  - Abstract pseudo-example: shorter but less believable and less actionable.
+
+3) Animated walkthrough implemented as lightweight docs asset with static fallback
+- Decision: Implement a lightweight step animation for the docs landing page and provide static frames/sequence for README compatibility.
+- Rationale: Animation clarifies temporal workflow (create then switch while another worktree remains active), while static assets ensure GitHub rendering compatibility.
+- Alternatives considered:
+  - Embedded video: strong storytelling but heavier payload and weaker accessibility defaults.
+  - GIF only: simple distribution but poorer clarity on high-DPI displays and limited control over reduced-motion behavior.
+
+4) Content parity enforced through shared structure, not shared runtime source
+- Decision: Define a stable message structure (headline, 3-step flow, minimal command example, outcome statement) and apply it in both repos.
+- Rationale: Repos are independent; structural parity is easier to maintain than trying to introduce cross-repo content imports.
+- Alternatives considered:
+  - Cross-repo content import/build step: tighter coupling and maintenance overhead.
+  - Independent authoring without constraints: higher drift risk between docs and README.
+
+## Risks / Trade-offs
+
+- [Risk] Animation may distract or hurt readability on some devices -> Mitigation: keep animation short/loop-safe, provide reduced-motion fallback, and ensure key message is understandable without motion.
+- [Risk] README and docs messaging can drift over time -> Mitigation: define identical section structure and wording checklist in follow-up tasks/review.
+- [Risk] Example commands could become outdated as CLI evolves -> Mitigation: use commands already covered by existing command specs and validate against current help output before merge.
+- [Risk] Too much detail in the hero area can reduce scannability -> Mitigation: enforce minimal copy, with links to deeper docs for details.
+
+## Migration Plan
+
+1. Update docs landing page content/components and add visual assets for the minimal workflow.
+2. Update `repos/arashi/README.md` with matching value proposition and static visual sequence.
+3. Validate docs rendering and repository markdown rendering.
+4. Roll back by reverting docs/README content changes if messaging or assets do not meet clarity/performance expectations.
+
+## Open Questions
+
+- Should the landing animation be authored as CSS/SVG sequence or as pre-rendered asset, given maintenance and visual fidelity trade-offs?
+- Which exact command snippets should be shown to balance correctness and brevity for first-time readers?
+- Should the example emphasize one persona (solo developer) or remain neutral for both solo and team contexts?

--- a/openspec/changes/explain-arashi-value/proposal.md
+++ b/openspec/changes/explain-arashi-value/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Arashi's core value is not obvious to first-time visitors because the docs landing page and CLI README explain features, but do not quickly show the multi-repo workflow outcome. We need a clearer value proposition now so users can immediately understand how Arashi helps them coordinate parallel worktrees across frontend and backend repositories.
+
+## What Changes
+
+- Rework the docs landing page hero/value section to explicitly communicate the multi-repo, parallel-worktree workflow and outcome.
+- Add a minimal end-to-end example that shows setting up a frontend repo and backend repo, creating worktrees for both, and switching focus while another worktree remains active.
+- Add visual walkthrough assets (static sequence and lightweight animation) that demonstrate the workflow steps from setup through switching.
+- Update CLI README guidance to include matching visuals and concise narrative aligned with the landing page message.
+
+## Capabilities
+
+### New Capabilities
+- `docs-landing-value-proposition`: Define requirements for landing-page messaging that clearly explains Arashi's multi-repo parallel-worktree value.
+- `multi-repo-worktree-visual-walkthrough`: Define requirements for minimal-example visuals and animation demonstrating add/create/switch flow across frontend and backend repos.
+- `cli-readme-value-example`: Define requirements for a CLI README section that mirrors the value proposition with a concise, visual-first example.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code/content: `repos/arashi-docs/` landing page content/components/assets and `repos/arashi/README.md`.
+- Affected systems: documentation site presentation and repository-level onboarding documentation.
+- Dependencies: existing docs site build pipeline/assets handling; no runtime CLI behavior or API contract changes.

--- a/openspec/changes/explain-arashi-value/specs/cli-readme-value-example/spec.md
+++ b/openspec/changes/explain-arashi-value/specs/cli-readme-value-example/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: CLI README SHALL include a value-focused multi-repo example section
+The CLI README SHALL include a dedicated section that explains Arashi's value through a minimal frontend-and-backend multi-repo workflow.
+
+#### Scenario: User reads README onboarding content
+- **WHEN** a user reads the top-level README for understanding what Arashi does
+- **THEN** the README contains a concise value-focused example section describing parallel multi-repo worktrees
+
+### Requirement: README example SHALL mirror the landing-page workflow narrative
+The README example SHALL use the same canonical workflow narrative as the docs landing page, including setup context and switch-while-other-worktree-active outcome.
+
+#### Scenario: Docs and README are compared
+- **WHEN** maintainers compare landing-page and README example content
+- **THEN** both sources present the same workflow story and outcome without contradictory framing
+
+### Requirement: README SHALL provide static visual support for the example
+The README SHALL include static visual assets or frame sequence that reinforce the minimal workflow in environments where landing-page animation is not available.
+
+#### Scenario: README is rendered on GitHub
+- **WHEN** the README is viewed in a markdown renderer without interactive animation
+- **THEN** the example still includes visual context that communicates the workflow steps

--- a/openspec/changes/explain-arashi-value/specs/docs-landing-value-proposition/spec.md
+++ b/openspec/changes/explain-arashi-value/specs/docs-landing-value-proposition/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Landing page SHALL communicate Arashi's multi-repo value above the fold
+The docs landing page SHALL present a primary value proposition that explains users can coordinate multiple repositories and multiple worktrees in parallel without losing context.
+
+#### Scenario: Visitor opens the landing page
+- **WHEN** a first-time visitor loads the docs landing page
+- **THEN** the hero/value section states Arashi's multi-repo parallel-worktree outcome before feature-level details
+
+### Requirement: Landing page SHALL include a canonical frontend-backend scenario
+The docs landing page SHALL include one minimal scenario that names a frontend repository and a backend repository and explains concurrent work across both.
+
+#### Scenario: Visitor scans the value section
+- **WHEN** the visitor reads the primary example on the landing page
+- **THEN** the example explicitly references both frontend and backend repositories as part of one workflow
+
+### Requirement: Landing page copy MUST remain concise and action-oriented
+The value section MUST use concise copy that emphasizes workflow outcome, and MUST avoid replacing the value proposition with exhaustive command reference text.
+
+#### Scenario: Value section content is reviewed
+- **WHEN** the landing-page value section is updated
+- **THEN** the section still communicates the outcome in short narrative form and defers detailed command coverage to deeper documentation

--- a/openspec/changes/explain-arashi-value/specs/multi-repo-worktree-visual-walkthrough/spec.md
+++ b/openspec/changes/explain-arashi-value/specs/multi-repo-worktree-visual-walkthrough/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Docs SHALL provide a visual walkthrough of the minimal multi-repo workflow
+The docs landing page SHALL provide visuals that depict adding repositories, creating worktrees, and switching between worktrees while another worktree remains active.
+
+#### Scenario: Visitor views the walkthrough
+- **WHEN** the visitor reaches the walkthrough section
+- **THEN** the visual sequence shows `add` -> `create` -> `switch` across frontend and backend repositories
+
+### Requirement: Walkthrough SHALL include motion and non-motion presentation modes
+The walkthrough SHALL include an animated presentation for motion-capable environments and SHALL provide an equivalent static sequence that preserves the same step order and meaning.
+
+#### Scenario: Reduced-motion preference is active
+- **WHEN** a visitor has reduced-motion preferences enabled
+- **THEN** the docs present a non-animated walkthrough that communicates the same workflow steps
+
+### Requirement: Walkthrough visuals MUST remain command-accurate
+Walkthrough steps MUST reflect command behavior and terminology used by current Arashi documentation so that visuals and text do not conflict.
+
+#### Scenario: Walkthrough copy and commands are validated
+- **WHEN** walkthrough assets and captions are reviewed before release
+- **THEN** the command labels and sequence match current documented Arashi command usage

--- a/openspec/changes/explain-arashi-value/tasks.md
+++ b/openspec/changes/explain-arashi-value/tasks.md
@@ -1,0 +1,25 @@
+## 1. Define canonical value narrative
+
+- [x] 1.1 Finalize the canonical frontend+backend scenario wording and command sequence (`add` -> `create` -> `switch`) for reuse across docs and README
+- [x] 1.2 Draft concise value-proposition copy for above-the-fold landing content that emphasizes parallel multi-repo worktrees
+- [x] 1.3 Add a parity checklist (headline, 3-step flow, outcome statement) to use during review of both repos
+
+## 2. Implement docs landing-page updates in `repos/arashi-docs`
+
+- [x] 2.1 Update landing hero/value section content to lead with the multi-repo parallel-worktree outcome
+- [x] 2.2 Add the minimal frontend+backend scenario section with short command-accurate captions
+- [x] 2.3 Implement lightweight animated walkthrough for the 3-step flow on the landing page
+- [x] 2.4 Implement reduced-motion/non-animated fallback that preserves the same workflow step order and meaning
+
+## 3. Implement README updates in `repos/arashi`
+
+- [x] 3.1 Add a value-focused README section describing the same canonical multi-repo workflow
+- [x] 3.2 Add static visual sequence/assets in README-compatible markdown format to mirror the landing walkthrough
+- [x] 3.3 Align README wording with landing-page structure and outcome statement to prevent messaging drift
+
+## 4. Validate and finalize
+
+- [x] 4.1 Verify command terminology and sequence in all captions/snippets against current Arashi docs/help output
+- [x] 4.2 Validate docs site rendering on desktop/mobile and confirm reduced-motion behavior communicates the workflow clearly
+- [x] 4.3 Validate README rendering on GitHub markdown and confirm visuals remain understandable without animation
+- [x] 4.4 Run repository-specific checks required by each touched repo and prepare changes for review


### PR DESCRIPTION
## Summary
- Add OpenSpec change artifacts for `explain-arashi-value` covering proposal, design, specs, and tasks.
- Capture requirements for landing-page value messaging, animated walkthrough behavior, and README/docs alignment intent.
- Define implementation task breakdown for docs-led delivery, with README updates deferred.

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-docs/pull/15
- Deferred companion PR (closed): https://github.com/corwinm/arashi/pull/46
- Related issue: https://github.com/corwinm/arashi-arashi/issues/92
- Closes #92