### PR TITLE
specs: archive init repo bootstrap change

### DIFF
--- a/openspec/changes/archive/2026-03-30-init-create-repo/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-30-init-create-repo/design.md
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`repos/arashi/src/commands/init.ts` currently assumes `process.cwd()` is already a git repository. If that check fails, the command returns `NOT_GIT_REPOSITORY` and prints guidance to run `git init` manually or change directories. That creates friction for first-time users and leaves the intended bootstrap path undocumented.
+
+This change spans the CLI implementation in `repos/arashi/`, onboarding docs in `repos/arashi-docs/`, and workflow guidance in `repos/arashi-skills/`. The command behavior is interactive, so the design needs to keep prompt handling, rollback, and dry-run behavior predictable while preserving the existing initialization flow for already-initialized repositories.
+
+Constraints:
+- Preserve current `arashi init` behavior when the command is run inside an existing git repository.
+- Keep the bootstrap target simple enough to avoid ambiguous path resolution or accidental repository creation outside the working directory.
+- Keep documentation and skill guidance consistent so the new workflow is discoverable without reading implementation details.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow `arashi init` to bootstrap a git repository when started from a non-repository directory.
+- Support two bootstrap targets: `.` for the current directory and a simple child directory name under the current working directory.
+- Reuse the existing Arashi initialization pipeline after the repository root is resolved so config, hooks, gitignore updates, and discovery stay consistent.
+- Update getting-started docs and Arashi skill references to explain where to run `init` and how the bootstrap target prompt works.
+
+**Non-Goals:**
+- Supporting arbitrary nested relative paths, parent traversal, or absolute paths as bootstrap targets.
+- Changing `arashi init` semantics for users who already run the command from a git repository root.
+- Adding remote setup, initial commits, README scaffolding, or other repository bootstrapping beyond `git init`.
+
+## Decisions
+
+1. Add bootstrap prompting before the hard git-repository failure path.
+- Decision: when `init` detects that `process.cwd()` is not a git repository, it will enter an interactive bootstrap flow instead of returning an immediate error.
+- Rationale: this keeps the beginner workflow inside one command and matches the issue's requested behavior.
+- Alternatives considered:
+- Keep the current failure and only improve docs: lower implementation cost, but still forces users through a manual bootstrap detour.
+- Add a required new flag for bootstrap: explicit, but worse for discoverability and unnecessary for the default interactive path.
+
+2. Constrain bootstrap target input to `.` or a direct child directory name.
+- Decision: accept `.` for the current directory and a single child directory name such as `my-arashi-repo`; reject empty input, path traversal, absolute paths, and multi-segment paths.
+- Rationale: this satisfies the requested workflow while avoiding surprising repository placement and keeping validation easy to explain.
+- Alternatives considered:
+- Allow any relative path: more flexible, but introduces ambiguous nesting and more edge cases around safety, messaging, and rollback.
+- Separate prompts for current-dir versus child-dir choices: clearer, but more verbose than a single validated target prompt.
+
+3. Refactor init execution around a resolved workspace root instead of raw `process.cwd()`.
+- Decision: split bootstrap path resolution from the existing initialization steps so the command can compute a target repository root, optionally create it with `git init`, and then run the current workspace setup logic against that resolved root.
+- Rationale: this avoids duplicating config, hook, gitignore, and discovery logic, and it keeps behavior aligned between existing repositories and newly created ones.
+- Alternatives considered:
+- Use `process.chdir()` and leave the current code structure intact: simpler mechanically, but makes tests and error handling harder to reason about.
+- Duplicate the init logic for bootstrapped repositories: faster initially, but increases drift risk and maintenance cost.
+
+4. Treat documentation and skill updates as part of the same contract.
+- Decision: update `repos/arashi-docs/docs/getting-started/index.md`, `repos/arashi-docs/docs/commands/init.md`, and the relevant Arashi skill references/tutorials so they explain both the existing-repository and bootstrap workflows with matching target examples.
+- Rationale: command behavior changes are only useful if new users can discover them, and repo policy already requires docs/skills review when command behavior changes.
+- Alternatives considered:
+- Update only CLI help text: too easy to miss for users who start from docs or skills.
+- Update docs but not skills: creates drift in onboarding guidance.
+
+## Risks / Trade-offs
+
+- [Risk] Interactive bootstrap introduces new prompt paths and failure modes in integration tests -> Mitigation: add dedicated tests for decline, current-directory, child-directory, and invalid-target flows.
+- [Risk] Users may initialize the wrong directory by mistake -> Mitigation: echo the resolved target clearly before creating the repository and keep accepted inputs narrowly scoped.
+- [Risk] Bootstrapping a child directory could break existing rollback assumptions -> Mitigation: track filesystem operations against the resolved root and verify cleanup behavior in new failure-path tests.
+- [Risk] Docs and skills may diverge from actual prompt wording over time -> Mitigation: update command docs and skill references in the same change and keep examples aligned with tested prompt semantics.
+
+## Migration Plan
+
+1. Refactor the init command so it can resolve a target root and optionally create a git repository before standard Arashi setup begins.
+2. Add integration coverage for non-repository bootstrap flows and preserve existing in-repository init coverage.
+3. Update docs and skill references to explain where to run `arashi init` and how `.` versus child-directory input behaves.
+4. Roll back by reverting the CLI bootstrap flow and matching docs/skills updates if the interactive behavior proves confusing or unstable.
+
+## Open Questions
+
+- Should dry-run mode display the resolved bootstrap target and simulated `git init` action even though it does not create a repository?
+- Should the command show a short post-success note when initialization was performed in a new child directory so users know to `cd` there for follow-up commands?

--- a/openspec/changes/archive/2026-03-30-init-create-repo/proposal.md
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Running `arashi init` in a non-git directory currently fails at the exact moment a new user is trying to get started. We need `init` to help bootstrap a repository in place or in a child path, and we need the onboarding docs and skills to show the intended workflow clearly.
+
+## What Changes
+
+- Update `arashi init` so that when it is run outside a git repository, it prompts the user to create a repository in the current directory or in a child directory instead of stopping with an error.
+- Support repository-target input that can be either `.` for the current directory or a simple child name such as `my-arashi-repo` for a new repository under the current working directory.
+- Continue the normal Arashi workspace initialization flow after the repository is created so first-time setup remains a single guided workflow.
+- Update getting-started documentation and skill guidance so users understand where to run `arashi init` and what the repository-target prompt means.
+
+## Capabilities
+
+### New Capabilities
+- `init-repository-bootstrap`: Define how `arashi init` bootstraps a git repository when invoked from a directory that is not already a repository.
+- `init-onboarding-guidance`: Define the required getting-started and skill guidance for running `arashi init` in the correct location and choosing current-directory versus child-directory repository creation.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected repo: `repos/arashi/` for CLI behavior, repository creation flow, and tests around `init`.
+- Affected repos/content: `repos/arashi-docs/` for getting-started guidance and `repos/arashi-skills/` for workflow guidance updates.
+- Affected behavior: first-run `init` experience in non-repository directories, prompt flow, and onboarding documentation.

--- a/openspec/changes/archive/2026-03-30-init-create-repo/specs/init-onboarding-guidance/spec.md
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/specs/init-onboarding-guidance/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Getting-started docs SHALL explain valid init starting locations
+The getting-started documentation SHALL explain that `arashi init` can be run from an existing repository root or from a non-repository parent directory when the user wants Arashi to create the repository during setup.
+
+#### Scenario: New user follows getting-started guide
+- **WHEN** a user reads the getting-started documentation before running `arashi init`
+- **THEN** the guide clearly states where to run the command for both existing-repository and new-repository workflows
+
+### Requirement: Onboarding guidance SHALL show current-dir and child-dir bootstrap examples
+The documented `init` workflow SHALL include examples showing that `.` initializes the current directory and that a simple child directory name creates a new repository below the current working directory.
+
+#### Scenario: User needs bootstrap target examples
+- **WHEN** a user reads the onboarding guidance for bootstrap setup
+- **THEN** the guidance includes one example using `.` and one example using a child directory name such as `my-arashi-repo`
+
+### Requirement: Skill guidance MUST match documented init bootstrap behavior
+The Arashi skill references and tutorials MUST describe the same init bootstrap workflow and target semantics as the getting-started documentation.
+
+#### Scenario: User follows Arashi skill guidance
+- **WHEN** a user reads the Arashi skill tutorial, workflow guide, or cheatsheet for `arashi init`
+- **THEN** the guidance matches the documented explanation of where to run the command and how repository-target input behaves

--- a/openspec/changes/archive/2026-03-30-init-create-repo/specs/init-repository-bootstrap/spec.md
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/specs/init-repository-bootstrap/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Init SHALL offer repository bootstrap outside git repo
+The `arashi init` command SHALL detect when it is run from a directory that is not already a git repository and SHALL offer an interactive repository-creation workflow instead of failing immediately.
+
+#### Scenario: Non-repository directory starts bootstrap flow
+- **WHEN** a user runs `arashi init` from a directory that is not a git repository
+- **THEN** the command prompts for repository creation before Arashi workspace setup continues
+
+#### Scenario: User declines repository creation
+- **WHEN** the command offers repository creation and the user declines
+- **THEN** the command exits without creating `.git`, `.arashi`, or managed repository directories in that location
+
+### Requirement: Init SHALL support current-directory repository creation
+The bootstrap workflow SHALL accept `.` as the repository target and SHALL initialize a git repository in the current working directory before continuing Arashi initialization there.
+
+#### Scenario: Current directory target selected
+- **WHEN** the user enters `.` as the bootstrap target
+- **THEN** the command initializes a git repository in the current working directory and writes Arashi workspace files relative to that directory
+
+### Requirement: Init SHALL support child-directory repository creation
+The bootstrap workflow SHALL accept a simple child directory name and SHALL create and initialize that child directory as a git repository before continuing Arashi initialization in the child root.
+
+#### Scenario: Child directory target selected
+- **WHEN** the user enters `my-arashi-repo` as the bootstrap target
+- **THEN** the command creates `<cwd>/my-arashi-repo`, initializes git there, and writes Arashi workspace files relative to the child directory
+
+### Requirement: Bootstrap target MUST be constrained to supported forms
+The bootstrap workflow MUST accept only `.` or a simple child directory name, and MUST reject absolute paths, parent traversal, or nested multi-segment paths.
+
+#### Scenario: Unsupported target rejected
+- **WHEN** the user enters `../repo`, `/tmp/repo`, or `foo/bar` as the bootstrap target
+- **THEN** the command reports that the target must be `.` or a direct child directory name and does not initialize a repository at the invalid path
+
+### Requirement: Bootstrapped repositories SHALL use standard init workflow
+After repository bootstrap succeeds, `arashi init` SHALL apply the same configuration, hook template creation, `.gitignore` updates, and repository discovery behavior that it applies when started inside an existing git repository.
+
+#### Scenario: Standard init continues after bootstrap
+- **WHEN** repository creation succeeds and `arashi init` continues
+- **THEN** the resolved repository root contains the standard Arashi configuration, hooks, ignore entries, and repository discovery results for the supplied init options

--- a/openspec/changes/archive/2026-03-30-init-create-repo/tasks.md
+++ b/openspec/changes/archive/2026-03-30-init-create-repo/tasks.md
@@ -1,0 +1,25 @@
+## 1. Implement init bootstrap flow in `repos/arashi`
+
+- [x] 1.1 Refactor `src/commands/init.ts` so the main initialization path can run against a resolved repository root instead of assuming `process.cwd()` is already a git repository
+- [x] 1.2 Add interactive non-repository bootstrap prompts that offer repository creation and validate only `.` or a simple child directory name
+- [x] 1.3 Create the target repository with `git init`, then continue the standard Arashi init flow with correct success, error, dry-run, and rollback behavior for the resolved root
+
+## 2. Add CLI coverage for bootstrap behavior
+
+- [x] 2.1 Add integration tests for declining bootstrap, bootstrapping the current directory with `.`, bootstrapping a child directory, and rejecting unsupported target paths
+- [x] 2.2 Update existing non-repository init expectations and confirm existing in-repository init tests still cover the unchanged success path
+
+## 3. Update onboarding docs in `repos/arashi-docs`
+
+- [x] 3.1 Update `docs/getting-started/index.md` to explain where to run `arashi init` for existing-repository and new-repository workflows
+- [x] 3.2 Update `docs/commands/init.md` with the bootstrap prompt behavior and examples for `.` and a child directory name
+
+## 4. Update Arashi skill guidance in `repos/arashi-skills`
+
+- [x] 4.1 Update the Arashi tutorial, workflow, and command reference content so the init bootstrap workflow matches the new CLI behavior
+- [x] 4.2 Update troubleshooting and cheatsheet guidance so non-repository `arashi init` usage points users to the current-directory and child-directory bootstrap options
+
+## 5. Validate touched repos
+
+- [x] 5.1 Run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi` after the CLI changes are complete
+- [x] 5.2 Run any applicable docs and skills validation checks, then verify the documented bootstrap examples and prompt wording match the implemented CLI flow


### PR DESCRIPTION
## Summary
- archive the completed OpenSpec change for init repository bootstrap behavior
- preserve the proposal, design, tasks, and delta specs tied to the rollout
- record the parent specs repo side of the coordinated issue delivery

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/49, https://github.com/corwinm/arashi-docs/pull/17, https://github.com/corwinm/arashi-skills/pull/17
- Related issue: https://github.com/corwinm/arashi-arashi/issues/129
- Closes #129