### PR TITLE
specs: archive exact switch target fix

### DIFF
--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/design.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/design.md
@@ -1,0 +1,61 @@
+## Context
+
+This bug spans the Arashi CLI in `repos/arashi/` and the VS Code extension in `repos/arashi-vscode/`. The extension worktree panel already knows the exact selected worktree path and currently passes that path into `arashi switch`, but the CLI treats the positional argument as a fuzzy filter over branch names and worktree paths. When multiple worktrees contain the same branch name or a similar path suffix such as `main`, a non-interactive extension invocation can fail with an ambiguity error even though the user selected a single concrete entry.
+
+The main constraint is preserving existing CLI ergonomics for manual switching. `arashi switch <filter>` should keep its current fuzzy selection behavior for terminal users, while IDE integrations need a deterministic path that bypasses ambiguity when they already know the intended target.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a deterministic switch mode that resolves a selected worktree by exact path identity.
+- Make extension-driven switch actions use that deterministic mode whenever the user already selected a concrete worktree.
+- Preserve current fuzzy and interactive `arashi switch <filter>` behavior for manual terminal use.
+- Keep the change aligned with existing Arashi CLI conventions where path-specific operations use an explicit flag.
+
+**Non-Goals:**
+- Redesign the broader switch discovery or interactive selection UX.
+- Introduce persistent configuration for exact-match behavior.
+- Redesign the extension switch selection UX beyond passing exact identity to existing CLI invocations.
+- Add new repository identity concepts beyond branch name and absolute worktree path.
+
+## Decisions
+
+### Decision: Add explicit path mode to `arashi switch`
+`arashi switch` should gain an explicit path-targeting mode, consistent with `arashi remove --path`, so callers can state that the argument is a concrete worktree path rather than a fuzzy filter. In path mode, the CLI should resolve the argument to one exact candidate by normalized absolute path and skip substring matching.
+
+Alternatives considered:
+- Infer exact mode automatically whenever the argument looks like a path: rejected because it would make CLI behavior harder to reason about and could break existing fuzzy path matching.
+- Add a new bespoke flag such as `--exact`: rejected because `--path` matches the existing command vocabulary and expresses the required identity directly.
+
+### Decision: Keep fuzzy matching as the default switch behavior
+The current positional-argument workflow is still useful for terminal users who want `arashi switch feature-auth` or partial path matching. Exact path mode should therefore be additive, not a replacement, so the CLI remains backwards compatible for interactive and non-interactive shell usage.
+
+Alternatives considered:
+- Change the default positional argument to exact matching: rejected because it would remove useful discovery behavior and likely break existing workflows.
+- Force all non-interactive switch calls to use exact matching: rejected because some automation may still intentionally rely on current filter semantics.
+
+### Decision: Make extension switch flows that select a worktree always use path mode
+Both the command-palette switch flow and the panel switch action already resolve a concrete `ArashiWorktree` with a known path before invoking the CLI. Those extension flows should pass that path using the explicit CLI path mode so branch-name collisions across repositories or sibling worktrees cannot change the selected target.
+
+Alternatives considered:
+- Keep sending the path as a plain positional filter and improve fuzzy scoring: rejected because any fuzzy strategy still risks ambiguity and does not match the explicit user selection in the UI.
+- Pass repository-plus-branch as a composite filter: rejected because the panel already has the exact path and path identity is the most stable key available today.
+
+## Risks / Trade-offs
+
+- [Users may assume `--path` accepts partial paths] -> Document that switch path mode requires an exact worktree path and keep the existing fuzzy mode available without the flag.
+- [Path normalization differences could create false negatives] -> Normalize both the CLI argument and discovered candidate paths before comparison and cover the behavior in tests.
+- [Extension and CLI behavior could drift if only one side changes] -> Treat the CLI flag and extension invocation update as one implementation unit with tests on both repositories.
+
+## Migration Plan
+
+1. Add `--path` handling and exact-path candidate resolution to `repos/arashi/`.
+2. Update `repos/arashi-vscode/` switch argument construction so extension-driven exact selections use `--path`.
+3. Refresh docs and skills guidance if switch troubleshooting or examples mention extension-driven switching.
+4. Validate the duplicated-branch scenario from issue `#131` with automated coverage and manual verification.
+
+Rollback is low risk because the change is additive. Reverting the new `--path` support and its extension call site restores the previous fuzzy-only behavior without any data migration.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/proposal.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Selecting a worktree from the VSCode UI should always switch to that exact entry, but choosing `main` currently forwards an ambiguous filter that can match multiple worktrees and fail. This breaks a core extension workflow and creates a mismatch between user intent in the UI and how the CLI resolves the target.
+
+## What Changes
+
+- Add exact-target switch behavior to `arashi switch` so callers that already know the intended worktree can bypass fuzzy filter matching.
+- Update VSCode switch flows that already know the selected worktree path to pass exact target identity instead of relying on ambiguous branch-name matching.
+- Preserve existing interactive and filter-based CLI behavior for manual `arashi switch <filter>` usage while ensuring deterministic switching for UI-driven flows.
+- Update docs and extension guidance where needed to describe the exact-target switch path used by IDE integrations.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `switch-command`: add a deterministic exact-target selection path for callers that already know which worktree should be opened.
+- `vscode-command-integration`: require extension-driven switch flows that select a concrete worktree to invoke the CLI with exact target identity.
+- `vscode-worktree-panel`: require panel-driven switch actions to resolve the selected worktree entry exactly, including entries whose branch names are duplicated across repositories.
+
+## Impact
+
+- CLI implementation in `repos/arashi/` for target resolution, flag parsing, and JSON/error handling around exact matching.
+- VS Code extension code in `repos/arashi-vscode/` for command-handler and tree-item switch invocation.
+- Documentation and skills content in `repos/arashi-docs/` and `repos/arashi-skills/` if user-facing switch behavior or troubleshooting guidance changes.

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/switch-command/spec.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/switch-command/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Filter and select a switch target
+The system SHALL support selecting a target by optional filter text, SHALL support exact worktree-path selection when the caller declares path mode, and SHALL require explicit disambiguation when multiple candidates remain.
+
+#### Scenario: Filter resolves to a single target
+- **WHEN** the user runs `arashi switch <filter>` and exactly one candidate matches branch or path
+- **THEN** the system selects that candidate without additional prompts
+
+#### Scenario: Multiple matches in interactive terminal
+- **WHEN** the user runs `arashi switch <filter>` in an interactive terminal and multiple candidates match
+- **THEN** the system prompts the user to choose exactly one target
+
+#### Scenario: Multiple matches in non-interactive terminal
+- **WHEN** the user runs `arashi switch <filter>` in a non-interactive terminal and multiple candidates match
+- **THEN** the system exits with an error instructing the user to provide a more specific filter
+
+#### Scenario: Exact path resolves selected worktree
+- **WHEN** the user runs `arashi switch --path <worktree-path>` and exactly one candidate has that normalized absolute worktree path
+- **THEN** the system selects that candidate without applying fuzzy branch or substring matching
+
+#### Scenario: Exact path does not match a worktree
+- **WHEN** the user runs `arashi switch --path <worktree-path>` and no candidate has that normalized absolute worktree path
+- **THEN** the system exits with an error explaining that no worktree exists at the requested path

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/vscode-command-integration/spec.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/vscode-command-integration/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Pass exact worktree identity for selected switch targets
+The extension SHALL invoke `arashi switch` with explicit worktree-path targeting whenever an extension switch flow has already resolved a concrete worktree selection.
+
+#### Scenario: Command palette switch uses exact path mode
+- **WHEN** a user runs the extension switch command, chooses a specific worktree from the native picker, and the extension invokes `arashi switch`
+- **THEN** the extension passes the selected worktree path using the CLI's explicit path-targeting mode instead of a fuzzy positional filter
+
+#### Scenario: Exact path mode preserves host-specific launch overrides
+- **WHEN** an extension switch flow invokes `arashi switch` for a selected worktree in VS Code, Cursor, or Kiro
+- **THEN** the extension still passes the matching host-specific IDE override together with the explicit path-targeting mode

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/vscode-worktree-panel/spec.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/specs/vscode-worktree-panel/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Provide contextual worktree actions
+The worktree panel SHALL provide contextual actions to switch to a worktree, remove a worktree, and add a repository, and SHALL invoke switch actions using the exact selected worktree identity rather than an ambiguous branch-name filter.
+
+#### Scenario: Switch action from panel
+- **WHEN** a user triggers switch on a selected worktree entry
+- **THEN** the extension executes the switch flow for that exact selected target and reports the outcome
+
+#### Scenario: Switch action handles duplicate branch names
+- **WHEN** multiple worktree entries share the same branch name and a user triggers switch on one specific entry from the panel
+- **THEN** the extension invokes the CLI in a way that selects only that chosen entry instead of failing on ambiguous matches
+
+#### Scenario: Add repository action from panel
+- **WHEN** a user triggers add repository from the panel
+- **THEN** the extension launches the add flow with native VS Code input UI and updates the panel after completion

--- a/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/tasks.md
+++ b/openspec/changes/archive/2026-03-30-fix-vscode-main-switch/tasks.md
@@ -1,0 +1,21 @@
+## 1. CLI exact-path switching
+
+- [x] 1.1 Add `--path` support to `arashi switch` and resolve selected worktrees by normalized absolute path when that mode is enabled.
+- [x] 1.2 Preserve existing fuzzy filter and interactive selection behavior when `--path` is not used, and add actionable no-match/error messaging for exact path mode.
+- [x] 1.3 Add or update CLI tests covering exact-path success, exact-path no-match failures, and the existing ambiguous-filter behavior.
+
+## 2. VS Code exact-target invocation
+
+- [x] 2.1 Update extension switch argument construction so flows that already selected a concrete worktree invoke `arashi switch` with `--path` while preserving host-specific IDE flags.
+- [x] 2.2 Update extension coverage for the command-palette switch flow and worktree-panel switch action, including duplicate-branch scenarios such as multiple `main` worktrees.
+
+## 3. Docs and skills synchronization
+
+- [x] 3.1 Review and update `repos/arashi-docs/` documentation if switch command or VSCode troubleshooting guidance needs to mention exact-path extension switching.
+- [x] 3.2 Review and update `repos/arashi-skills/` guidance and examples if they reference VSCode-driven switch behavior affected by this change.
+
+## 4. Validation
+
+- [x] 4.1 Run the required lint, test, and build checks for `repos/arashi/` after the CLI changes land.
+- [x] 4.2 Run the relevant test and build checks for `repos/arashi-vscode` after the extension changes land.
+- [x] 4.3 Manually verify the issue `#131` scenario by switching to a selected `main` worktree from the VSCode extension UI without ambiguity errors.

--- a/openspec/specs/switch-command/spec.md
+++ b/openspec/specs/switch-command/spec.md
@@ -15,7 +15,7 @@ The system SHALL discover existing git worktrees associated with the current Ara
 - **THEN** the system exits with an error explaining that no switch targets were found
 
 ### Requirement: Filter and select a switch target
-The system SHALL support selecting a target by optional filter text and SHALL require explicit disambiguation when multiple candidates remain.
+The system SHALL support selecting a target by optional filter text, SHALL support exact worktree-path selection when the caller declares path mode, and SHALL require explicit disambiguation when multiple candidates remain.
 
 #### Scenario: Filter resolves to a single target
 - **WHEN** the user runs `arashi switch <filter>` and exactly one candidate matches branch or path
@@ -28,6 +28,14 @@ The system SHALL support selecting a target by optional filter text and SHALL re
 #### Scenario: Multiple matches in non-interactive terminal
 - **WHEN** the user runs `arashi switch <filter>` in a non-interactive terminal and multiple candidates match
 - **THEN** the system exits with an error instructing the user to provide a more specific filter
+
+#### Scenario: Exact path resolves selected worktree
+- **WHEN** the user runs `arashi switch --path <worktree-path>` and exactly one candidate has that normalized absolute worktree path
+- **THEN** the system selects that candidate without applying fuzzy branch or substring matching
+
+#### Scenario: Exact path does not match a worktree
+- **WHEN** the user runs `arashi switch --path <worktree-path>` and no candidate has that normalized absolute worktree path
+- **THEN** the system exits with an error explaining that no worktree exists at the requested path
 
 ### Requirement: Open a new terminal context at the selected worktree
 The system SHALL open a new terminal or editor context rooted at the selected worktree path and SHALL support config-driven default launch behavior, explicit IDE CLI overrides, and launch opt-out handling.

--- a/openspec/specs/vscode-command-integration/spec.md
+++ b/openspec/specs/vscode-command-integration/spec.md
@@ -75,3 +75,14 @@ The extension SHALL detect whether it is running in VS Code, Cursor, or Kiro and
 #### Scenario: Unsupported host omits IDE override
 - **WHEN** the extension runs `arashi switch` in a compatible host that does not map to a supported IDE override
 - **THEN** the extension invokes the CLI without adding an IDE-specific launch flag
+
+### Requirement: Pass exact worktree identity for selected switch targets
+The extension SHALL invoke `arashi switch` with explicit worktree-path targeting whenever an extension switch flow has already resolved a concrete worktree selection.
+
+#### Scenario: Command palette switch uses exact path mode
+- **WHEN** a user runs the extension switch command, chooses a specific worktree from the native picker, and the extension invokes `arashi switch`
+- **THEN** the extension passes the selected worktree path using the CLI's explicit path-targeting mode instead of a fuzzy positional filter
+
+#### Scenario: Exact path mode preserves host-specific launch overrides
+- **WHEN** an extension switch flow invokes `arashi switch` for a selected worktree in VS Code, Cursor, or Kiro
+- **THEN** the extension still passes the matching host-specific IDE override together with the explicit path-targeting mode

--- a/openspec/specs/vscode-worktree-panel/spec.md
+++ b/openspec/specs/vscode-worktree-panel/spec.md
@@ -41,11 +41,15 @@ The worktree panel SHALL source its data from Arashi CLI commands invoked with `
 - **THEN** the extension preserves the last known panel state when available and shows an actionable refresh error
 
 ### Requirement: Provide contextual worktree actions
-The worktree panel SHALL provide contextual actions to switch to a worktree, remove a worktree, and add a repository.
+The worktree panel SHALL provide contextual actions to switch to a worktree, remove a worktree, and add a repository, and SHALL invoke switch actions using the exact selected worktree identity rather than an ambiguous branch-name filter.
 
 #### Scenario: Switch action from panel
 - **WHEN** a user triggers switch on a selected worktree entry
-- **THEN** the extension executes the switch flow for that target and reports the outcome
+- **THEN** the extension executes the switch flow for that exact selected target and reports the outcome
+
+#### Scenario: Switch action handles duplicate branch names
+- **WHEN** multiple worktree entries share the same branch name and a user triggers switch on one specific entry from the panel
+- **THEN** the extension invokes the CLI in a way that selects only that chosen entry instead of failing on ambiguous matches
 
 #### Scenario: Add repository action from panel
 - **WHEN** a user triggers add repository from the panel


### PR DESCRIPTION
## Summary
- archive the completed `fix-vscode-main-switch` OpenSpec change
- sync the `switch-command`, `vscode-command-integration`, and `vscode-worktree-panel` specs with the exact-target switch behavior
- record the spec-side contract for resolving duplicate `main` worktrees from IDE flows

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/50, https://github.com/corwinm/arashi-vscode/pull/6, https://github.com/corwinm/arashi-docs/pull/18, https://github.com/corwinm/arashi-skills/pull/18
- Related issue: https://github.com/corwinm/arashi-arashi/issues/131

Closes #131