### PR TITLE
specs: archive VS Code refresh UI fix

### DIFF
--- a/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/design.md
+++ b/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The VS Code extension currently has two different refresh paths for the worktree panel. `WorktreeTreeDataProvider.refresh()` refreshes the underlying store and then fires `onDidChangeTreeData`, but command handlers use `WorktreeStore.refresh()` directly for manual refresh and post-action refresh flows. That updates in-memory state without notifying VS Code that the tree needs to be re-rendered, which explains how the UI can report a successful refresh while still showing stale entries.
+
+The main constraint is preserving the current separation between data fetching and UI rendering. The extension should keep using the store as the source of truth for worktree state, while any user-visible refresh path must still notify the tree view when the store changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make manual refresh always update the rendered worktree tree when newly discovered data differs from the previous state.
+- Ensure post-action refreshes use the same UI-invalidating path so create, add, remove, and similar flows do not leave stale panel entries behind.
+- Preserve existing banner behavior for empty states, parse failures, and invalid workspace errors.
+- Add regression coverage for refreshes that change the visible worktree set.
+
+**Non-Goals:**
+- Change the CLI `list` contract or add new refresh-specific CLI flags.
+- Redesign the worktree panel UI, sorting, or status presentation.
+- Introduce background polling or automatic refresh beyond current command-driven behavior.
+
+## Decisions
+
+### Decision: Route command-triggered panel refreshes through a provider-aware callback
+Command handlers should not call `WorktreeStore.refresh()` directly when the intent is to update the visible panel. Instead, activation should wire handlers to a refresh callback that uses the existing provider refresh flow, so every user-facing refresh both updates the store and emits a tree data change event.
+
+Alternatives considered:
+- Fire the tree-data event manually from command handlers: rejected because handlers should not know about VS Code tree provider internals.
+- Move the event emitter into the store: rejected because the store is intentionally UI-agnostic and should remain reusable in tests.
+
+### Decision: Keep one data source and reuse existing store semantics
+The provider-aware refresh path should continue to rely on `WorktreeStore.refresh()` for state transitions, including last-known-state preservation and banner generation. This keeps the bug fix focused on wiring the UI update correctly instead of duplicating refresh logic in multiple places.
+
+Alternatives considered:
+- Reimplement refresh handling separately for the panel command: rejected because it would risk divergence in empty-state and error behavior.
+- Force the provider to own all state directly: rejected because it would be a broader refactor than this bug requires.
+
+### Decision: Add regression tests at the extension integration layer
+Tests should cover a refresh sequence where the underlying discovered worktrees change and verify that the panel refresh path updates what the UI would render, not just the store contents. This targets the real failure mode more directly than unit tests that only assert store state changes.
+
+Alternatives considered:
+- Only test the store: rejected because the bug is the missing UI invalidation step, not the data fetch itself.
+- Rely on manual verification only: rejected because this is a regression-prone event-wiring bug.
+
+## Risks / Trade-offs
+
+- [Refresh wiring becomes more coupled to activation setup] -> Keep the handler dependency surface small by injecting a single refresh callback rather than the full tree provider.
+- [Tests may overfit VS Code implementation details] -> Assert observable panel-refresh outcomes through the provider/handler boundary instead of private emitter behavior.
+- [Other code paths may still call the store directly in the future] -> Centralize command refresh usage behind the same helper and cover it with regression tests.
+
+## Migration Plan
+
+1. Update `repos/arashi-vscode/` activation and command wiring so user-triggered panel refreshes flow through the tree provider refresh path.
+2. Keep `WorktreeStore.refresh()` as the shared state transition mechanism behind the provider path.
+3. Add or update extension tests that simulate changed worktree discovery across refreshes and verify the rendered panel state updates.
+4. Run the extension test, lint, and build checks to confirm the fix without behavior regressions.
+
+Rollback is low risk because the fix is confined to extension refresh wiring and tests. Reverting the handler/provider wiring change restores current behavior without data migration.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/proposal.md
+++ b/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The VS Code worktree panel can report a successful refresh without showing worktrees that were created or discovered since the panel last rendered. This breaks trust in the panel as a live view of workspace state and makes common extension workflows appear unreliable.
+
+## What Changes
+
+- Update VS Code panel refresh behavior so a successful manual refresh always updates the visible tree with the latest discovered worktrees.
+- Align panel refresh and post-action refresh flows around a single UI update path so newly added, removed, or discovered worktrees appear in the same session.
+- Add regression coverage for refresh scenarios where the underlying worktree list changes between refreshes.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `vscode-worktree-panel`: require manual and action-driven refresh flows to update the rendered panel state immediately when discovery returns changed worktree data.
+
+## Impact
+
+- Extension implementation in `repos/arashi-vscode/`, especially the worktree store, tree provider, and command handlers that trigger refresh.
+- Extension tests in `repos/arashi-vscode/tests/` covering manual refresh and UI synchronization.
+- No expected CLI contract or user configuration changes.

--- a/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/specs/vscode-worktree-panel/spec.md
+++ b/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/specs/vscode-worktree-panel/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Keep panel state synchronized after actions
+The worktree panel SHALL refresh after mutating actions and SHALL provide a manual refresh command, and every successful refresh path SHALL update the rendered panel state in the same session using the latest queried worktree data.
+
+#### Scenario: State refresh after mutation
+- **WHEN** a panel action mutates worktrees or repository configuration
+- **THEN** the panel refreshes and reflects updated state in the same session
+
+#### Scenario: Manual refresh
+- **WHEN** a user invokes panel refresh
+- **THEN** the extension re-queries Arashi state and updates displayed entries
+
+#### Scenario: Manual refresh shows newly discovered worktrees
+- **WHEN** the discovered worktree set changes before a user invokes panel refresh
+- **THEN** the panel replaces its visible entries with the latest discovered worktree data in that same session

--- a/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/tasks.md
+++ b/openspec/changes/archive/2026-03-31-fix-vscode-refresh-ui/tasks.md
@@ -1,0 +1,14 @@
+## 1. Refresh wiring
+
+- [x] 1.1 Update `repos/arashi-vscode/` activation and command wiring so manual refresh and post-action refresh flows invoke a provider-aware refresh path that both updates the store and invalidates the tree view.
+- [x] 1.2 Preserve the existing worktree-store refresh behavior for empty states, parse-failure fallback, and invalid-workspace banners while routing UI-facing refreshes through the shared panel refresh path.
+
+## 2. Regression coverage
+
+- [x] 2.1 Add or update extension tests to cover a refresh sequence where discovered worktrees change and the visible panel entries update in the same session.
+- [x] 2.2 Add or update command-handler coverage to ensure manual refresh and action-triggered refreshes both use the UI-refresh path instead of only mutating store state.
+
+## 3. Validation
+
+- [x] 3.1 Run the relevant lint, test, and build checks for `repos/arashi-vscode` after the refresh fix lands.
+- [x] 3.2 Manually verify issue `#136` by changing the available worktrees, invoking the VS Code panel refresh action, and confirming the new entries appear without reloading the window.

--- a/openspec/specs/vscode-worktree-panel/spec.md
+++ b/openspec/specs/vscode-worktree-panel/spec.md
@@ -67,7 +67,7 @@ The extension MUST require explicit confirmation for destructive panel actions a
 - **THEN** the extension executes the action without a confirmation prompt
 
 ### Requirement: Keep panel state synchronized after actions
-The worktree panel SHALL refresh after mutating actions and SHALL provide a manual refresh command.
+The worktree panel SHALL refresh after mutating actions and SHALL provide a manual refresh command, and every successful refresh path SHALL update the rendered panel state in the same session using the latest queried worktree data.
 
 #### Scenario: State refresh after mutation
 - **WHEN** a panel action mutates worktrees or repository configuration
@@ -76,3 +76,7 @@ The worktree panel SHALL refresh after mutating actions and SHALL provide a manu
 #### Scenario: Manual refresh
 - **WHEN** a user invokes panel refresh
 - **THEN** the extension re-queries Arashi state and updates displayed entries
+
+#### Scenario: Manual refresh shows newly discovered worktrees
+- **WHEN** the discovered worktree set changes before a user invokes panel refresh
+- **THEN** the panel replaces its visible entries with the latest discovered worktree data in that same session


### PR DESCRIPTION
## Summary
- sync the `vscode-worktree-panel` spec with the validated refresh behavior for issue #136
- archive the completed `fix-vscode-refresh-ui` OpenSpec change for traceability

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-vscode/pull/8
- Related issue: https://github.com/corwinm/arashi-arashi/issues/136
- Closes #136