### PR TITLE
specs: archive status fetch change

### DIFF
--- a/openspec/changes/archive/2026-04-01-status-fetch/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-status-fetch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-status-fetch/design.md
+++ b/openspec/changes/archive/2026-04-01-status-fetch/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`repos/arashi/src/commands/status.ts` currently derives ahead/behind information from `git status --porcelain=v1 --branch`, which only reflects whatever remote-tracking refs are already present locally. That keeps the command fast, but it means `arashi status` can report stale branch divergence until the user runs a separate fetch.
+
+The CLI already has targeted remote refresh logic in `repos/arashi/src/lib/git-remote.ts` for comparing a branch with its upstream. This change can reuse the same remote/branch resolution pattern instead of introducing a second fetch strategy. The main constraint is that `status` must stay useful in offline or partially authenticated environments; a failed fetch should not erase otherwise valid local file-status information.
+
+Constraints:
+- Keep the change scoped to `repos/arashi` unless follow-up review shows docs or skills need command-behavior notes.
+- Preserve the existing missing-repository behavior and exit semantics for true repository errors.
+- Avoid broad `git fetch --all` behavior that adds unnecessary latency or side effects for every configured remote.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Refresh tracked remote refs before calculating branch ahead/behind information during `arashi status`.
+- Keep refresh behavior targeted to the repository's resolved tracking remote and branch.
+- Preserve local status output when remote refresh fails, while making the stale-remote condition visible to the user.
+- Add tests that cover successful fetch refresh, skip behavior for repositories without a usable remote target, and fetch-failure fallback.
+
+**Non-Goals:**
+- Changing `arashi status` flags or adding a user-configurable fetch policy in this change.
+- Reworking unrelated status formatting or summary behavior.
+- Converting all git operations in the CLI to a new abstraction beyond the fetch helper reuse needed here.
+
+## Decisions
+
+1. Reuse targeted remote-resolution and fetch behavior
+- Decision: Extract or share a helper that resolves the repository's remote-tracking target and performs a targeted `git fetch --prune <remote> +refs/heads/<branch>:refs/remotes/<remote>/<branch>` before status parsing.
+- Rationale: The targeted fetch pattern already exists in `git-remote.ts`, avoids the cost of fetching every remote, and keeps branch-tracking refresh consistent across command paths.
+- Alternatives considered:
+- Run plain `git fetch` for every repository: simpler, but slower and broader than necessary.
+- Keep status read-only and document stale tracking: lowest effort, but does not solve the issue.
+
+2. Treat fetch failures as degradations, not repository status failures
+- Decision: Record fetch problems separately from `RepoStatus.error` so `arashi status` can still show local dirty/clean state and any currently available branch data.
+- Rationale: Network or credential issues are common and should not make the command unusable when local repository inspection still works.
+- Alternatives considered:
+- Fail the entire repository status on fetch error: easier to wire into current error handling, but too disruptive.
+- Ignore fetch errors silently: keeps output clean, but hides that ahead/behind data may be stale.
+
+3. Skip refresh when no remote-tracking target can be resolved
+- Decision: Do not attempt a fetch for missing repositories, detached HEAD states without a resolvable branch target, or repositories with no configured remotes.
+- Rationale: These cases cannot produce a meaningful remote refresh and should preserve current local-only behavior.
+- Alternatives considered:
+- Force a generic remote lookup and fail if none is found: adds noise without improving correctness.
+
+4. Surface warnings in all status output modes without changing exit-on-error semantics
+- Decision: Extend status formatting so fetch degradation is visible in default, verbose, and short output, but do not count warnings as hard errors for exit-code purposes.
+- Rationale: Users need to know when divergence data may be stale, but automation should only fail on real repository inspection errors.
+- Alternatives considered:
+- Show warnings only in verbose mode: simpler, but easy to miss in common usage.
+- Exit non-zero on warnings: too strict for transient network problems.
+
+## Risks / Trade-offs
+
+- [Risk] Targeted fetch adds network latency to `arashi status` -> Mitigation: fetch only the resolved tracking ref and continue checking repositories in parallel.
+- [Risk] Warning display can clutter short output -> Mitigation: keep the warning concise and only show it when refresh actually fails.
+- [Risk] Shared fetch logic between `status` and `git-remote` can drift if copied instead of extracted -> Mitigation: prefer a small shared helper in git utilities over duplicating resolution rules.
+- [Risk] Remote resolution edge cases (custom upstreams, detached HEAD, unusual remotes) could cause false warnings -> Mitigation: add tests for upstream-present, upstream-missing, no-remote, and detached cases.
+
+## Migration Plan
+
+1. Extract or add a shared git helper for resolving the status fetch target and performing the targeted fetch.
+2. Update `status` command flow to run the refresh before parsing status output for each eligible repository.
+3. Extend `RepoStatus` formatting to carry non-fatal fetch warnings separately from hard errors.
+4. Add unit and integration coverage for refreshed tracking info and degraded fetch behavior.
+5. Roll back by removing the pre-status fetch step and warning plumbing if the added network dependency proves too disruptive.
+
+## Open Questions
+
+- Should short output show a compact warning token inline, or append a short text note when refresh fails?
+- Should the main repository and child repositories use identical fetch behavior even when one has no upstream configured?
+- Do we want a follow-up change to make remote refresh optional for users who prefer the fastest possible status checks?

--- a/openspec/changes/archive/2026-04-01-status-fetch/proposal.md
+++ b/openspec/changes/archive/2026-04-01-status-fetch/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`arashi status` currently reads branch tracking data without refreshing remote refs first, so ahead/behind information can be stale even when the repository is otherwise healthy. We need the command to refresh remote state before reporting status so users can trust the branch summary when deciding whether to pull, push, or switch context.
+
+## What Changes
+
+- Update `arashi status` to run `git fetch` before collecting branch tracking information for repositories that exist locally and have a remote to refresh.
+- Preserve existing local status reporting when a remote refresh cannot run, instead of turning transient network or auth issues into a full loss of repository status.
+- Surface fetch-related degradation clearly enough that users can tell when remote ahead/behind data may be stale.
+- Add command-level coverage for successful refreshes and fetch-failure fallback behavior.
+
+## Capabilities
+
+### New Capabilities
+- `status-command`: Define status-command requirements for refreshing remote-tracking data before rendering repository status output.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected repo: `repos/arashi`.
+- Affected code: `src/commands/status.ts`, git helper utilities, and status command tests.
+- Affected systems: CLI status output, branch tracking accuracy, and git network access during status checks.
+- Dependencies: existing git subprocess utilities and repository-level remote configuration.

--- a/openspec/changes/archive/2026-04-01-status-fetch/specs/status-command/spec.md
+++ b/openspec/changes/archive/2026-04-01-status-fetch/specs/status-command/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Refresh tracked remote state before reporting branch divergence
+The system SHALL refresh the resolved remote-tracking branch for each locally present repository before `arashi status` reports ahead/behind information.
+
+#### Scenario: Repository has a resolvable upstream branch
+- **WHEN** the user runs `arashi status` for a repository whose current branch maps to a remote-tracking branch
+- **THEN** the command runs a targeted `git fetch` for that tracking branch before parsing branch divergence output
+- **AND** the reported ahead/behind counts reflect the refreshed remote-tracking ref
+
+#### Scenario: Repository has no remote-tracking target
+- **WHEN** the user runs `arashi status` for a repository that has no configured remote, no upstream, or no resolvable branch target
+- **THEN** the command skips the remote refresh for that repository
+- **AND** the command still reports the repository's local branch and working-tree status
+
+### Requirement: Preserve local status when remote refresh fails
+The system MUST continue reporting local repository status when the remote refresh step fails and MUST identify that remote-tracking information may be stale.
+
+#### Scenario: Fetch fails for a reachable local repository
+- **WHEN** the user runs `arashi status` and the repository's targeted `git fetch` fails because of network, authentication, or remote command errors
+- **THEN** the command still reports the repository's local clean/dirty status
+- **AND** the command indicates that remote-tracking information could not be refreshed for that repository
+- **AND** the fetch failure is not treated as a missing-repository or git-status execution failure

--- a/openspec/changes/archive/2026-04-01-status-fetch/tasks.md
+++ b/openspec/changes/archive/2026-04-01-status-fetch/tasks.md
@@ -1,0 +1,14 @@
+## 1. Add remote refresh support for status checks
+
+- [x] 1.1 Extract or add a shared git helper that resolves a repository's tracking remote/branch and performs the targeted fetch used by `arashi status`
+- [x] 1.2 Extend status result data so non-fatal fetch refresh warnings are tracked separately from hard repository errors
+
+## 2. Integrate refresh behavior into `arashi status`
+
+- [x] 2.1 Update repository status collection to run the targeted remote refresh before parsing branch divergence for eligible repositories and skip refresh when no target can be resolved
+- [x] 2.2 Update default, verbose, and short status output to show stale-remote warnings without turning fetch degradation into a command failure
+
+## 3. Verify behavior in tests and validation
+
+- [x] 3.1 Add or update unit tests covering successful refresh, no-remote skip behavior, and fetch-failure fallback for local status reporting
+- [x] 3.2 Run `bun test`, `bun run lint`, and `bun run build` in `repos/arashi`

--- a/openspec/specs/status-command/spec.md
+++ b/openspec/specs/status-command/spec.md
@@ -1,0 +1,27 @@
+# status-command Specification
+
+## Purpose
+TBD - created by syncing change status-fetch. Update Purpose after archive.
+
+## Requirements
+### Requirement: Refresh tracked remote state before reporting branch divergence
+The system SHALL refresh the resolved remote-tracking branch for each locally present repository before `arashi status` reports ahead/behind information.
+
+#### Scenario: Repository has a resolvable upstream branch
+- **WHEN** the user runs `arashi status` for a repository whose current branch maps to a remote-tracking branch
+- **THEN** the command runs a targeted `git fetch` for that tracking branch before parsing branch divergence output
+- **AND** the reported ahead/behind counts reflect the refreshed remote-tracking ref
+
+#### Scenario: Repository has no remote-tracking target
+- **WHEN** the user runs `arashi status` for a repository that has no configured remote, no upstream, or no resolvable branch target
+- **THEN** the command skips the remote refresh for that repository
+- **AND** the command still reports the repository's local branch and working-tree status
+
+### Requirement: Preserve local status when remote refresh fails
+The system MUST continue reporting local repository status when the remote refresh step fails and MUST identify that remote-tracking information may be stale.
+
+#### Scenario: Fetch fails for a reachable local repository
+- **WHEN** the user runs `arashi status` and the repository's targeted `git fetch` fails because of network, authentication, or remote command errors
+- **THEN** the command still reports the repository's local clean/dirty status
+- **AND** the command indicates that remote-tracking information could not be refreshed for that repository
+- **AND** the fetch failure is not treated as a missing-repository or git-status execution failure


### PR DESCRIPTION
## Summary
- sync the new `status-command` main spec from the completed `status-fetch` change
- archive the completed OpenSpec change under `openspec/changes/archive/2026-04-01-status-fetch`
- keep the parent specs workflow aligned with the implemented CLI behavior

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/53
- Related issue: https://github.com/corwinm/arashi-arashi/issues/138

Closes #138