### PR TITLE
specs: archive VS Code remove flow fix

### DIFF
--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/design.md
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The VS Code extension already owns the remove confirmation UX for both command-palette and panel-triggered worktree removal. In `createCommandHandlers`, both remove entry points confirm in native VS Code UI and then call `buildRemoveArgs({ target, pathMode: true })`, but the helper currently builds only the target path and `--path`. That leaves `arashi remove` free to prompt for confirmation again, which breaks extension-driven removal because the command is launched without an interactive terminal flow for answering that prompt.
+
+The extension also executes several commands that can take noticeable time, such as add, clone, pull, sync, switch, create, init, and remove, but it currently waits silently until success or failure notifications appear. That makes it hard to distinguish a slow operation from a stuck one.
+
+The main constraint is preserving the existing extension contract: the editor, not the CLI, should own selection and confirmation UX for extension-driven commands. The fix should stay inside `repos/arashi-vscode/`, keep exact path targeting, avoid changing CLI behavior or command names, and keep VS Code UI APIs out of the core command logic where possible.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make extension-driven remove flows succeed after a single native VS Code confirmation.
+- Ensure both command-palette removal and panel trash-button removal invoke `arashi remove` against the exact selected worktree in forced non-interactive mode.
+- Show native in-progress feedback for long-running extension command executions.
+- Add regression coverage for confirmed removal, progress wrapping, and cancellation behavior.
+
+**Non-Goals:**
+- Change the Arashi CLI remove contract or introduce new CLI flags.
+- Redesign VS Code notifications, tree item labels, or remove command names.
+- Add new multi-step confirmation UI beyond the existing extension confirmation prompt.
+
+## Decisions
+
+### Decision: Treat the VS Code confirmation as the authoritative destructive-confirmation step
+After the user confirms removal in the extension, the extension should invoke `arashi remove` with `--force` so the CLI does not ask for confirmation again. This keeps the destructive decision in the native VS Code UI where the user initiated the action and matches the extension's existing responsibility for collecting inputs before command execution.
+
+Alternatives considered:
+- Keep the CLI confirmation and try to surface it interactively from the extension: rejected because the current extension flow is not terminal-interactive and would remain fragile.
+- Change the CLI to auto-detect extension callers: rejected because the problem is specific to extension argument construction, not the CLI contract.
+
+### Decision: Keep remove targeting centralized in the shared remove-argument helper
+Both remove entry points already resolve an exact worktree path before invocation, so the smallest correct change is to keep using the shared remove helper and extend it to build the full non-interactive argument list for extension-driven removal. This avoids duplicating `--force` wiring across handlers and keeps command-palette and panel flows aligned.
+
+Alternatives considered:
+- Append `--force` separately in each handler: rejected because it duplicates the same contract in multiple call sites.
+- Introduce a separate helper just for panel removal: rejected because both entry points need identical CLI behavior.
+
+### Decision: Cover the regression at both helper and command-handler levels
+Unit coverage should verify the final remove argument list includes forced path mode, and integration coverage should verify that cancelled removals do not execute the CLI while confirmed removals do. Progress coverage should assert that long-running command handlers route execution through a shared progress wrapper. This combination protects both the argument contract and the user-visible flow.
+
+Alternatives considered:
+- Only add integration coverage: rejected because a helper-level assertion catches accidental argument regressions more directly.
+- Only add unit coverage: rejected because the bug is user-visible in command-handler execution, not just argument assembly.
+
+### Decision: Inject a shared progress runner from the extension host
+The command handlers should accept a single progress-runner dependency that wraps async command execution, while the VS Code extension host supplies the concrete `window.withProgress` implementation. This keeps VS Code UI details out of the handler logic, avoids duplicating spinner code across commands, and lets tests assert progress behavior with a simple mock.
+
+Alternatives considered:
+- Call `window.withProgress` directly from each handler: rejected because it would spread UI concerns across many command flows.
+- Add progress only for remove: rejected because other long-running commands already share the same stalled-looking behavior.
+
+## Risks / Trade-offs
+
+- [Forced remove could bypass safety if a future caller uses the helper without confirmation] -> Keep extension remove flows routed through confirmation-first handlers and cover cancellation behavior in tests.
+- [Spec and implementation could drift between command-palette and panel flows] -> Reuse the same remove helper and add integration assertions for extension-triggered removal.
+- [Success messaging may obscure whether the CLI was actually invoked with forced mode] -> Assert the executed command arguments directly in tests.
+- [Frequent progress notifications could become noisy] -> Restrict the wrapper to command executions that can take noticeable time and reuse concise titles.
+
+## Migration Plan
+
+1. Update the VS Code remove argument builder so extension-driven remove invocations include `--force` together with exact path targeting.
+2. Keep the current confirmation prompts in both remove handlers and continue to short-circuit when the user cancels.
+3. Route long-running command executions through a shared VS Code progress-notification wrapper supplied by the extension host.
+4. Add or update unit and integration tests in `repos/arashi-vscode/tests/` to verify forced invocation, progress wrapping, and cancellation behavior.
+5. Run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi-vscode/` when implementation begins.
+
+Rollback is low risk because the change is confined to extension argument construction and tests.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/proposal.md
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The VS Code extension currently confirms worktree removal in native editor UI but still invokes `arashi remove` in a way that can trigger an interactive CLI confirmation. In editor-driven remove flows, that extra prompt causes the operation to fail instead of completing against the selected worktree, and long-running extension commands provide little visible feedback while they are in progress.
+
+## What Changes
+
+- Update VS Code remove flows to treat the editor confirmation as the single destructive confirmation step and invoke the CLI in non-interactive forced mode afterward.
+- Ensure both command-palette removal and panel trash-button removal target the exact selected worktree without falling back to a prompt-driven CLI flow.
+- Show a native busy indicator while long-running Arashi commands execute so users can tell the extension is still working.
+- Add regression coverage for successful forced remove invocations, visible progress wrapping for long-running commands, and cancellation behavior when the user declines the VS Code confirmation.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `vscode-command-integration`: require editor-confirmed remove commands to invoke `arashi remove` without a second interactive confirmation prompt and require long-running commands to surface in-progress feedback.
+- `vscode-worktree-panel`: require panel remove actions to execute against the clicked worktree using the extension confirmation as the only confirmation step.
+
+## Impact
+
+- Extension command handling in `repos/arashi-vscode/`, especially remove command argument construction, confirmation flow wiring, and shared progress notification behavior for long-running commands.
+- Extension tests in `repos/arashi-vscode/tests/` covering command-palette and tree-item remove behavior plus progress-wrapped command execution.
+- No expected CLI changes; this proposal aligns extension behavior with existing non-interactive CLI support.

--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/specs/vscode-command-integration/spec.md
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/specs/vscode-command-integration/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Use native VS Code input and confirmation flows
+The extension SHALL gather required command inputs and confirmations through native VS Code UI components before invoking Arashi, and SHALL treat extension-collected confirmation for destructive remove flows as the single confirmation step before invoking the CLI.
+
+#### Scenario: Command requires user input
+- **WHEN** a command is triggered without required arguments
+- **THEN** the extension prompts with native VS Code input or selection UI and passes the collected values to the CLI invocation
+
+#### Scenario: User cancels input flow
+- **WHEN** a user dismisses an input or selection prompt
+- **THEN** the extension cancels command execution and reports a non-error cancellation message
+
+#### Scenario: Confirmed remove runs without a second CLI prompt
+- **WHEN** a user confirms an extension-driven worktree remove action after the extension has resolved the exact target worktree
+- **THEN** the extension invokes `arashi remove` for that selected target in non-interactive forced mode and does not require a second CLI confirmation prompt
+
+### Requirement: Provide consistent execution feedback
+The extension SHALL present command success and failure outcomes through standardized notifications and an output channel entry containing command context, and SHALL show a native progress notification while long-running Arashi commands are executing.
+
+#### Scenario: Command succeeds
+- **WHEN** an Arashi command exits successfully
+- **THEN** the extension shows a success notification and logs the executed command context in the output channel
+
+#### Scenario: Command fails
+- **WHEN** an Arashi command exits with an error
+- **THEN** the extension shows an error notification with remediation guidance and logs stderr details in the output channel
+
+#### Scenario: Long-running command shows progress
+- **WHEN** the extension runs a long-running Arashi command such as add, clone, create, init, pull, remove, switch, or sync
+- **THEN** the extension shows a native in-progress notification until the command finishes and then reports the final outcome

--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/specs/vscode-worktree-panel/spec.md
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/specs/vscode-worktree-panel/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Provide contextual worktree actions
+The worktree panel SHALL provide title actions to create a worktree and refresh the panel, SHALL provide item actions to switch to a worktree, remove a worktree, and open a repository-focused window, and SHALL execute destructive worktree removal against the exact clicked worktree without requiring a second selection step or a second confirmation prompt from the CLI.
+
+#### Scenario: Create worktree from panel title
+- **WHEN** a user triggers create from the panel title area
+- **THEN** the extension launches the native VS Code create flow for `arashi create`
+
+#### Scenario: Switch action from panel
+- **WHEN** a user triggers switch on a selected worktree entry
+- **THEN** the extension executes the switch flow for that exact selected target and reports the outcome
+
+#### Scenario: Remove action confirms once for the clicked worktree
+- **WHEN** a user triggers remove on a worktree entry from the panel
+- **THEN** the extension asks for confirmation for that clicked worktree, invokes removal for that exact target in forced path mode after confirmation, and does not require the user to confirm again before removal
+
+#### Scenario: Open repository from panel
+- **WHEN** a user triggers the open action on a repository entry from the panel
+- **THEN** the extension opens a new editor window focused on that repository root

--- a/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/tasks.md
+++ b/openspec/changes/archive/2026-04-07-fix-vscode-remove-worktree/tasks.md
@@ -1,0 +1,16 @@
+## 1. Remove flow update
+
+- [x] 1.1 Update `repos/arashi-vscode/src/commands/flows.ts` so extension-driven remove arguments include `--force` together with exact path targeting.
+- [x] 1.2 Keep both command-palette and panel remove handlers in `repos/arashi-vscode/src/commands/handlers.ts` gated by native VS Code confirmation and invoking the shared forced remove argument path for the selected worktree.
+- [x] 1.3 Add a shared progress-notification runner in `repos/arashi-vscode/` and apply it to long-running command executions.
+
+## 2. Regression coverage
+
+- [x] 2.1 Update `repos/arashi-vscode/tests/unit/flows.test.ts` to assert the remove helper builds forced path-mode arguments.
+- [x] 2.2 Update `repos/arashi-vscode/tests/integration/registration-and-panel.test.ts` to assert cancelled remove flows do not execute the CLI and confirmed remove flows execute `arashi remove` with forced exact-target arguments.
+- [x] 2.3 Update `repos/arashi-vscode/tests/` to assert long-running commands route through the shared progress wrapper.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun test`, and `bun run build` in `repos/arashi-vscode/` after the implementation lands.
+- [x] 3.2 Manually verify issue `#143` by removing a worktree through both the command palette and the panel trash action and confirming the extension shows a busy indicator and does not require a second CLI confirmation prompt.

--- a/openspec/specs/vscode-command-integration/spec.md
+++ b/openspec/specs/vscode-command-integration/spec.md
@@ -11,7 +11,7 @@ The extension SHALL register VS Code commands for `arashi init`, `arashi add`, `
 - **THEN** each core Arashi command appears in the command palette and can be bound to a keybinding
 
 ### Requirement: Use native VS Code input and confirmation flows
-The extension SHALL gather required command inputs and confirmations through native VS Code UI components before invoking Arashi.
+The extension SHALL gather required command inputs and confirmations through native VS Code UI components before invoking Arashi, and SHALL treat extension-collected confirmation for destructive remove flows as the single confirmation step before invoking the CLI.
 
 #### Scenario: Command requires user input
 - **WHEN** a command is triggered without required arguments
@@ -20,6 +20,10 @@ The extension SHALL gather required command inputs and confirmations through nat
 #### Scenario: User cancels input flow
 - **WHEN** a user dismisses an input or selection prompt
 - **THEN** the extension cancels command execution and reports a non-error cancellation message
+
+#### Scenario: Confirmed remove runs without a second CLI prompt
+- **WHEN** a user confirms an extension-driven worktree remove action after the extension has resolved the exact target worktree
+- **THEN** the extension invokes `arashi remove` for that selected target in non-interactive forced mode and does not require a second CLI confirmation prompt
 
 ### Requirement: Request machine-readable CLI output for parsed flows
 The extension SHALL pass `--json` to Arashi CLI commands whenever the extension parses command output for UI state, decision-making, or validation.
@@ -33,7 +37,7 @@ The extension SHALL pass `--json` to Arashi CLI commands whenever the extension 
 - **THEN** the extension shows an actionable error and records diagnostic details in the extension output channel
 
 ### Requirement: Provide consistent execution feedback
-The extension SHALL present command success and failure outcomes through standardized notifications and an output channel entry containing command context.
+The extension SHALL present command success and failure outcomes through standardized notifications and an output channel entry containing command context, and SHALL show a native progress notification while long-running Arashi commands are executing.
 
 #### Scenario: Command succeeds
 - **WHEN** an Arashi command exits successfully
@@ -42,6 +46,10 @@ The extension SHALL present command success and failure outcomes through standar
 #### Scenario: Command fails
 - **WHEN** an Arashi command exits with an error
 - **THEN** the extension shows an error notification with remediation guidance and logs stderr details in the output channel
+
+#### Scenario: Long-running command shows progress
+- **WHEN** the extension runs a long-running Arashi command such as add, clone, create, init, pull, remove, switch, or sync
+- **THEN** the extension shows a native in-progress notification until the command finishes and then reports the final outcome
 
 ### Requirement: Preserve compatibility across VS Code forks
 The extension SHALL declare `engines.vscode` as `^1.96.2` and SHALL use stable VS Code APIs so it can run in VS Code and compatible forks such as Cursor.

--- a/openspec/specs/vscode-worktree-panel/spec.md
+++ b/openspec/specs/vscode-worktree-panel/spec.md
@@ -41,7 +41,7 @@ The worktree panel SHALL source its data from Arashi CLI commands invoked with `
 - **THEN** the extension preserves the last known panel state when available and shows an actionable refresh error
 
 ### Requirement: Provide contextual worktree actions
-The worktree panel SHALL provide title actions to create a worktree and refresh the panel, SHALL provide item actions to switch to a worktree, remove a worktree, and open a repository-focused window, and SHALL execute destructive worktree removal against the exact clicked worktree without requiring a second selection step.
+The worktree panel SHALL provide title actions to create a worktree and refresh the panel, SHALL provide item actions to switch to a worktree, remove a worktree, and open a repository-focused window, and SHALL execute destructive worktree removal against the exact clicked worktree without requiring a second selection step or a second confirmation prompt from the CLI.
 
 #### Scenario: Create worktree from panel title
 - **WHEN** a user triggers create from the panel title area
@@ -53,7 +53,7 @@ The worktree panel SHALL provide title actions to create a worktree and refresh 
 
 #### Scenario: Remove action confirms once for the clicked worktree
 - **WHEN** a user triggers remove on a worktree entry from the panel
-- **THEN** the extension asks for confirmation for that clicked worktree and does not require the user to select the worktree again before removal
+- **THEN** the extension asks for confirmation for that clicked worktree, invokes removal for that exact target in forced path mode after confirmation, and does not require the user to confirm again before removal
 
 #### Scenario: Open repository from panel
 - **WHEN** a user triggers the open action on a repository entry from the panel


### PR DESCRIPTION
## Summary
- archive the completed `fix-vscode-remove-worktree` OpenSpec change and sync its requirement deltas into the main spec set
- document that VS Code remove flows use extension-owned confirmation, forced exact-target removal, and progress feedback for long-running commands
- close issue #143 from the parent specs PR

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-vscode/pull/10
- Related issue: https://github.com/corwinm/arashi-arashi/issues/143

Closes #143