### PR TITLE
specs: archive missing remote branch status change

### DIFF
--- a/.pi/prompts/ship.md
+++ b/.pi/prompts/ship.md
@@ -1,0 +1,129 @@
+---
+description: Create coordinated multi-repo commits and optional PRs
+---
+
+Create coordinated commits across the parent specs repo and every changed child repo, then optionally open linked PRs.
+
+**Input**: Optionally specify an issue URL/number or change name after `/ship`.
+
+Examples:
+- `/ship`
+- `/ship https://github.com/corwinm/arashi-arashi/issues/123`
+- `/ship #123`
+
+**Goal**
+
+- Commit all relevant changes in all affected repositories.
+- Reference the original spec issue in every commit.
+- Ask whether to open PRs.
+- If yes, create PRs for each affected repository with cross-links.
+- Ensure the parent specs PR closes the related issue.
+
+**Steps**
+
+1. **Detect affected repositories**
+
+   - Treat the current workspace root as the **parent specs repo**.
+   - Discover child repos under `repos/*` that are git repositories.
+   - For each repository (parent + children), run `git status --short`.
+   - Keep only repositories with changes.
+   - If no repositories have changes, report and stop.
+
+2. **Resolve the canonical issue reference**
+
+   Prefer in this order:
+
+   1) Argument passed to `/ship` if it is an issue URL/number
+   2) Parse modified `specs/*/spec.md` files for an issue URL (`https://github.com/.../issues/<n>`)
+   3) Parse changed OpenSpec artifacts (`openspec/changes/*`) for a linked issue URL
+
+   If still missing or ambiguous, use **AskUserQuestion** to request the canonical issue URL.
+
+   Also derive:
+   - `issueUrl` (full URL)
+   - `issueNumber` (numeric, when available)
+   - `issueRefShort` (`owner/repo#number` when available)
+
+3. **Commit each changed repository (one commit per repo)**
+
+   For each changed repo, in sequence:
+
+   - Run `git status`, `git diff`, and recent `git log` to align with local commit style.
+   - Stage relevant tracked/untracked files.
+   - Exclude likely secret files (`.env`, `*.pem`, credentials files).
+   - Draft a focused commit message (why-oriented) and include issue reference.
+
+   Commit message guidance:
+   - Parent specs repo: include issue reference in body (for example `Refs: <issueUrl>`).
+   - Child repos: include same issue reference in body.
+
+   Quality checks before each commit:
+   - Run project-required checks when available.
+   - For `repos/arashi`, run:
+     - `bun run lint`
+     - `bun test`
+     - `bun run build`
+   - Fix failures before committing.
+
+4. **Prompt to create PRs**
+
+   Use **AskUserQuestion**:
+   - "Create PRs for all committed repositories now?"
+   - options: `Yes` / `No`
+
+   If `No`, stop after reporting committed repos and branches.
+
+5. **If Yes, create PRs for each committed repository**
+
+   For each committed repo:
+
+   - Verify current branch and remote tracking.
+   - Push with upstream if needed: `git push -u origin <branch>`.
+   - Create PR with `gh pr create` (title/body based on repo changes).
+   - Capture every PR URL.
+
+6. **Backfill cross-references in every PR body**
+
+   After all PRs exist, update each PR body so links are bidirectional.
+
+   Required body section in every PR:
+
+   ```markdown
+   ## Related
+   - Companion implementation/spec PRs: <all other PR URLs>
+   - Related issue: <issueUrl>
+   ```
+
+   Additional rule for parent specs PR:
+   - Include a closing keyword for the issue (`Closes #<issueNumber>` when valid in that repo; otherwise `Closes <issueUrl>`).
+
+   Additional rule for non-parent PRs:
+   - Do **not** close the issue.
+   - Include issue as reference only.
+
+7. **Report final results**
+
+   Show:
+   - issue used (`issueUrl`)
+   - committed repositories with commit SHAs
+   - PR URL per repository (if created)
+   - confirmation that parent PR closes the issue
+
+**Output**
+
+At minimum:
+
+- Parent specs repo commit status
+- Child repo commit status
+- PR decision (`Yes`/`No`)
+- PR URLs (if created)
+- Cross-link/issue linkage confirmation
+
+**Guardrails**
+
+- One commit per changed repository (no cross-repo commit attempts).
+- Do not commit unchanged repositories.
+- Do not amend commits unless explicitly requested.
+- Never use destructive git operations (`reset --hard`, force-push) unless explicitly requested.
+- Do not skip hooks unless explicitly requested.
+- Ask before proceeding only when issue resolution is ambiguous or missing.

--- a/openspec/changes/archive/2026-04-17-warn-remote-branch/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-warn-remote-branch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-17-warn-remote-branch/design.md
+++ b/openspec/changes/archive/2026-04-17-warn-remote-branch/design.md
@@ -1,0 +1,67 @@
+## Context
+
+`arashi status` currently refreshes each repository's remote-tracking branch before reading `git status`, then stores any fetch failure as a generic `refreshWarning`. The default and verbose renderers always print branch information first and append that warning as a separate yellow line afterward. For a missing remote branch, this produces noisy output even though the local branch state is still valid and the warning is really about the branch mapping itself.
+
+This change affects the status command flow in `repos/arashi/src/commands/status.ts` and the remote refresh helper in `repos/arashi/src/lib/git-remote.ts`. The implementation should preserve the existing behavior for missing repositories, detached HEADs, and generic remote refresh failures.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect the specific fetch failure that means the expected remote branch does not exist.
+- Preserve local status collection and parsing when that remote branch is missing.
+- Render the missing-remote condition inline on the Branch line for human-readable status output.
+- Keep generic stale-remote warnings for authentication, network, and other fetch failures.
+- Cover the new behavior with unit tests around detection and formatting.
+
+**Non-Goals:**
+- Changing how upstream branches are resolved.
+- Changing branch divergence calculations for successfully refreshed remotes.
+- Redesigning the short status format beyond what is needed to keep warning output accurate.
+- Adding new configuration or CLI flags.
+
+## Decisions
+
+### 1. Classify remote refresh failures instead of storing only a generic warning string
+Add structured metadata for remote refresh outcomes so rendering logic does not need to infer behavior from a free-form error string. The status path should distinguish at least:
+- generic refresh failure where remote tracking may be stale
+- missing remote branch/ref for the resolved target
+
+This can be implemented either by returning a typed failure from `fetchRemoteTrackingTarget` or by normalizing the result in `checkRepoStatus`. The preferred approach is to classify the error near `fetchRemoteTrackingTarget`, because that helper has the fetch target information and already owns remote-refresh semantics.
+
+**Alternative considered:** keep a single warning string and match on it in the formatters. Rejected because it would couple rendering to raw git error text and make tests brittle.
+
+### 2. Render missing remote branches on the Branch line in default and verbose output
+When the refresh classifier reports that the remote branch is missing, the default and verbose renderers should replace the usual remote-tracking display with an inline warning in the remote position, for example:
+
+`Branch: feat/my-branch → couldn't find remote ref refs/heads/feat/my-branch`
+
+The full Branch line should be yellow to communicate warning severity while still showing the local branch. Generic refresh failures should continue using the existing separate warning line.
+
+**Alternative considered:** keep the separate warning line and shorten the message. Rejected because the issue specifically requests the missing remote to appear where the remote branch would normally be shown.
+
+### 3. Preserve local branch parsing from `git status`
+The command should still run `getGitStatus`, parse the local branch name, and collect file status even when remote refresh reports a missing ref. The missing-remote state is a display concern layered on top of valid local status data, not a repository failure.
+
+**Alternative considered:** clear `remoteBranch` and treat the repository as having no remote. Rejected because the local repository may still be configured to track a remote branch that simply has not been pushed yet.
+
+### 4. Keep short output semantically accurate with minimal change
+Short output has no dedicated Branch line, so it should continue to summarize repository status compactly. If warning metadata is shown there, it should use a concise missing-remote marker distinct from the generic stale-remote marker.
+
+**Alternative considered:** leave short output unchanged. Accepted only if the new metadata is not exposed there; otherwise the output would silently lose warning information.
+
+## Risks / Trade-offs
+
+- **Git error text varies across environments** → Match the missing-ref case narrowly and normalize the displayed message so tests do not rely on unrelated prefixes such as `Git command failed:` or `fatal:`.
+- **Renderer complexity increases** → Use structured warning metadata so each formatter can branch on a small enum-like state.
+- **Potential overlap with repositories that truly have no remote** → Continue treating “no remote/upstream can be resolved” as the existing no-refresh path rather than the missing-remote-branch warning case.
+- **Short-format expectations may shift** → Keep short output changes minimal and test only the new warning marker behavior.
+
+## Migration Plan
+
+- No data migration required.
+- Ship as a normal CLI behavior change.
+- Rollback is limited to restoring the prior warning classification and formatting if users prefer the previous output.
+
+## Open Questions
+
+- Whether the inline message should preserve the raw git wording exactly or use a friendlier normalized phrase. The initial implementation should favor a normalized message that still identifies the missing ref path.

--- a/openspec/changes/archive/2026-04-17-warn-remote-branch/proposal.md
+++ b/openspec/changes/archive/2026-04-17-warn-remote-branch/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+When `arashi status` cannot fetch a matching remote branch, it currently emits a large yellow warning block with the raw git error. That preserves local status information, but it makes the output feel noisier than necessary for a common warning case where the local branch simply has no corresponding remote branch yet.
+
+## What Changes
+
+- Update `arashi status` to recognize the specific case where the resolved remote branch does not exist on the remote.
+- Show the missing-remote condition inline on the Branch line instead of as a separate warning block.
+- Render the Branch line in yellow for this warning state while still showing local branch information and preserving other local repository status details.
+- Keep existing warning behavior for other remote refresh failures such as authentication, network, or generic git command errors.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `status-command`: Change how `arashi status` reports a missing remote branch so the branch line shows the warning inline instead of printing the generic stale remote-tracking warning block.
+
+## Impact
+
+- Affected code: `repos/arashi/src/commands/status.ts`, `repos/arashi/src/lib/git-remote.ts`, and related unit/integration tests.
+- User-visible behavior: `arashi status` output changes for repositories whose local branch has no matching branch on the remote.
+- Dependencies: No new runtime dependencies expected.

--- a/openspec/changes/archive/2026-04-17-warn-remote-branch/specs/status-command/spec.md
+++ b/openspec/changes/archive/2026-04-17-warn-remote-branch/specs/status-command/spec.md
@@ -1,21 +1,4 @@
-# status-command Specification
-
-## Purpose
-TBD - created by syncing change status-fetch. Update Purpose after archive.
-
-## Requirements
-### Requirement: Refresh tracked remote state before reporting branch divergence
-The system SHALL refresh the resolved remote-tracking branch for each locally present repository before `arashi status` reports ahead/behind information.
-
-#### Scenario: Repository has a resolvable upstream branch
-- **WHEN** the user runs `arashi status` for a repository whose current branch maps to a remote-tracking branch
-- **THEN** the command runs a targeted `git fetch` for that tracking branch before parsing branch divergence output
-- **AND** the reported ahead/behind counts reflect the refreshed remote-tracking ref
-
-#### Scenario: Repository has no remote-tracking target
-- **WHEN** the user runs `arashi status` for a repository that has no configured remote, no upstream, or no resolvable branch target
-- **THEN** the command skips the remote refresh for that repository
-- **AND** the command still reports the repository's local branch and working-tree status
+## MODIFIED Requirements
 
 ### Requirement: Preserve local status when remote refresh fails
 The system MUST continue reporting local repository status when the remote refresh step fails. When the failure indicates that the resolved remote branch ref does not exist, the system MUST surface that condition inline on the branch display instead of showing the generic stale remote-tracking warning. For other remote refresh failures, the system MUST continue to indicate that remote-tracking information may be stale.

--- a/openspec/changes/archive/2026-04-17-warn-remote-branch/tasks.md
+++ b/openspec/changes/archive/2026-04-17-warn-remote-branch/tasks.md
@@ -1,0 +1,17 @@
+## 1. Remote refresh classification
+
+- [x] 1.1 Detect the git fetch failure that means the resolved remote branch ref does not exist and represent it separately from generic stale remote-tracking failures.
+- [x] 1.2 Thread the structured remote refresh warning state through `checkRepoStatus` without breaking local branch parsing or file status collection.
+
+## 2. Status output updates
+
+- [x] 2.1 Update default and verbose `arashi status` output to render a missing remote branch inline on the Branch line in warning styling.
+- [x] 2.2 Suppress the generic `Remote tracking may be stale` warning for the missing-remote case while preserving it for other refresh failures.
+- [x] 2.3 Adjust short output only as needed to keep warning reporting accurate for missing-remote and generic stale cases.
+
+## 3. Tests and review
+
+- [x] 3.1 Add unit coverage for missing-remote fetch detection and for preserving local status when that condition occurs.
+- [x] 3.2 Add formatter tests for inline branch warnings and for preserving existing generic stale-warning behavior.
+- [x] 3.3 Run `bun test`, `bun run lint`, and `bun run build` in `repos/arashi`.
+- [x] 3.4 Review whether `repos/arashi-docs` or `repos/arashi-skills` need follow-up updates for the changed `arashi status` output.


### PR DESCRIPTION
## Summary
- archive the completed `warn-remote-branch` OpenSpec change
- sync the `status-command` spec with the missing-remote-branch warning behavior

## Validation
- openspec validate status-command

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/56
- Related issue: https://github.com/corwinm/arashi-arashi/issues/148

Closes #148
