### PR TITLE
specs: archive create extension defaults change

### DIFF
--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/design.md
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The CLI already supports workspace-scoped `defaults.create` settings, and the VS Code extension already detects which editor host it is running in for switch flows. Today, extension-driven `arashi create` invocations do not identify that host to the CLI, so the CLI resolves the same post-create defaults it would use for a terminal invocation.
+
+That creates a mismatch between intent and behavior. Terminal defaults are often chosen to open a new shell or editor window after create, while an extension flow is already running inside an editor and usually wants to stay in that context unless the workspace explicitly configures otherwise. The fix needs to preserve current terminal behavior, avoid surprising extra launches from the extension, and fit into the existing `.arashi/config.json` defaults model without introducing a second unrelated configuration system.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let the CLI resolve create defaults differently for editor-hosted invocations than for terminal invocations.
+- Add a config shape for editor-specific create overrides that can be keyed by supported editor host.
+- Make the VS Code extension pass its detected host when invoking `arashi create`.
+- Define deterministic precedence so explicit CLI flags still win and editor-hosted create falls back to no defaults when no editor override exists.
+
+**Non-Goals:**
+- Redesigning the existing `create` CLI flag surface beyond the minimum host-context input needed for extension calls.
+- Changing switch-command host override behavior, which already has explicit editor flags.
+- Adding editor-specific defaults for unrelated commands unless they are required to support create.
+- Changing terminal invocation behavior for workspaces that already rely on `defaults.create`.
+
+## Decisions
+
+### 1) Add host-scoped create overrides under the existing defaults tree
+Extend the config structure under `defaults` with an editor-scoped section keyed by supported hosts, for example `defaults.editors.vscode.create`. Reusing the current defaults tree keeps create behavior discoverable in one place and lets the CLI normalize one config model instead of merging separate top-level concepts.
+
+**Alternatives considered:**
+- Add a new top-level `editorDefaults` block: rejected because it splits closely related create-default behavior across two config roots.
+- Store extension-only settings inside the VS Code extension config: rejected because the desired behavior is workspace-specific and should travel with `.arashi/config.json`.
+
+### 2) Pass editor host explicitly from extension to CLI create invocations
+Add a dedicated create invocation input for editor host context, such as a hidden or internal `--editor-host <host>` argument. The extension already resolves `vscode`, `cursor`, or `kiro`, so it can pass that context directly instead of relying on ambient environment detection.
+
+**Alternatives considered:**
+- Infer host from environment variables in the CLI: rejected because subprocess environments vary and the extension already has a more reliable host signal.
+- Reuse `--vscode` or similar launch flags for create context: rejected because those flags express launch behavior, not config-resolution context.
+
+### 3) Use no-default fallback for editor-hosted create when no editor override exists
+When `arashi create` is invoked with an editor host, resolution order becomes: explicit positive flags, explicit opt-out flags, host-specific create defaults, then no post-create defaults. Generic `defaults.create` continues to apply to terminal invocations only.
+
+This matches the issue's intent: extension-driven create should either override the generic defaults or behave as if no defaults were configured. It also avoids duplicate editor launches and other terminal-oriented post-create actions when the extension did not ask for them.
+
+**Alternatives considered:**
+- Fall back from host-specific defaults to generic `defaults.create`: rejected because it preserves the current surprising behavior for extension-driven create.
+- Always disable defaults for extension flows with no config support: rejected because users explicitly asked for configurable editor or extension defaults.
+
+### 4) Reuse existing create-default resolution and extension argument builders
+Implement the change by extending the current create-default resolution path in the CLI and the existing `buildCreateArgs` logic in the extension. This keeps the change localized to the code that already owns default resolution and command invocation, which minimizes regression risk and keeps tests focused.
+
+**Alternatives considered:**
+- Add a separate extension-only create command in the CLI: rejected because it would duplicate the existing create flow.
+- Hardcode `--no-switch --no-launch` in the extension: rejected because it blocks editor-specific defaults and pushes policy into the wrong layer.
+
+## Risks / Trade-offs
+
+- [Config shape becomes harder to understand] -> Mitigate by keeping editor overrides nested under the existing `defaults` tree and documenting precedence with examples.
+- [CLI host-context argument leaks into general user-facing docs] -> Mitigate by treating it as extension-oriented plumbing and exposing only the behavior contract in user docs.
+- [Editor-specific fallback surprises users who expected generic defaults to carry over] -> Mitigate by documenting that editor-hosted create is intentionally isolated from terminal defaults unless the workspace opts in.
+- [Host list grows over time] -> Mitigate by centralizing the supported host enum already shared by the extension and CLI.
+
+## Migration Plan
+
+1. Extend CLI config types, normalization, and schema generation to support editor-scoped create defaults.
+2. Add create invocation support for editor-host context and update default-resolution logic to branch on that context.
+3. Update the VS Code extension create flow to pass the detected editor host when available.
+4. Add CLI and extension tests for terminal precedence, editor override precedence, and no-default fallback behavior.
+5. Update user-facing config guidance with examples for generic create defaults versus editor-specific create defaults.
+6. Rollback strategy: remove the new editor-scoped config entries and stop passing editor-host context; terminal behavior remains unchanged.
+
+## Open Questions
+
+- Final config key naming: should the nested section be `defaults.editors`, `defaults.extension`, or another host-scoped label?
+- Should unknown editor-host values be rejected at argument-parse time or ignored as "no host context"?
+- Do we want to expose the host-context argument in CLI help, or keep it as an internal extension-facing contract?

--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/proposal.md
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`arashi create` currently resolves the same workspace defaults whether it is run from a terminal or from the VS Code extension. That makes extension-driven create flows inherit terminal-oriented switch and launch behavior, which can trigger the wrong follow-up action or duplicate editor launches unless users avoid defaults entirely.
+
+## What Changes
+
+- Add editor-aware create default resolution so extension-driven `arashi create` can use editor-specific overrides instead of always inheriting the generic CLI defaults.
+- Define a workspace config section for editor or extension defaults, with support for VS Code-hosted create flows and a safe fallback that applies no post-create defaults when no editor override is configured.
+- Update the VS Code extension create flow to identify its editor host when invoking the CLI so the CLI can resolve the correct defaults for that invocation.
+- Document the precedence between generic create defaults, editor-specific create defaults, and explicit CLI flags or opt-outs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `create-command-defaults`: extend create-default resolution to support editor-specific overrides and no-default fallback for extension-triggered create flows.
+- `vscode-command-integration`: require the extension create flow to pass its host context so CLI default resolution can distinguish editor invocations from terminal invocations.
+
+## Impact
+
+- CLI config parsing and create default resolution in `repos/arashi/src/`.
+- VS Code extension create argument construction and command invocation in `repos/arashi-vscode/src/`.
+- Tests in `repos/arashi/tests/` and `repos/arashi-vscode/tests/` covering precedence, host-aware default resolution, and extension create behavior.
+- User-facing configuration and workflow guidance in `repos/arashi/README.md` and companion docs if broader guidance needs updating.

--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/specs/create-command-defaults/spec.md
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/specs/create-command-defaults/spec.md
@@ -1,8 +1,5 @@
-# create-command-defaults Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change faster-defaults-with-create. Update Purpose after archive.
-## Requirements
 ### Requirement: Resolve create defaults from configuration and CLI
 The system SHALL resolve `arashi create` execution behavior from CLI flags, invocation context, and workspace configuration using deterministic precedence.
 
@@ -18,39 +15,6 @@ The system SHALL resolve `arashi create` execution behavior from CLI flags, invo
 - **WHEN** the user runs `arashi create <branch>` with explicit flags for switch or shell/editor launch
 - **THEN** the command uses explicit CLI values instead of configured defaults for those options
 
-### Requirement: Support default auto-switch after create
-The system SHALL support a configurable default that switches to the newly created worktree after successful creation.
-
-#### Scenario: Auto-switch default enabled
-- **WHEN** create auto-switch default is enabled and `arashi create <branch>` succeeds
-- **THEN** the command performs switch behavior for the new worktree without requiring `--switch`
-
-#### Scenario: Auto-switch default disabled
-- **WHEN** create auto-switch default is disabled and the user does not pass `--switch`
-- **THEN** the command completes create without switching
-
-### Requirement: Support default shell or editor launch after create
-The system SHALL support a configurable default launch command for `arashi create` that opens the newly created worktree in the user's preferred environment.
-
-#### Scenario: Launch default configured
-- **WHEN** the user runs `arashi create <branch>` and a default launch command is configured
-- **THEN** the command invokes the configured launch behavior for the new worktree
-
-#### Scenario: Launch default not configured
-- **WHEN** the user runs `arashi create <branch>` and no launch default is configured
-- **THEN** the command does not launch shell/editor behavior unless explicitly requested by CLI flags
-
-### Requirement: Allow one-off opt-out from create defaults
-The system SHALL provide per-invocation opt-out flags that disable configured create defaults without modifying workspace configuration.
-
-#### Scenario: Opt out of configured auto-switch
-- **WHEN** auto-switch is configured by default and the user invokes `arashi create <branch>` with a switch opt-out flag
-- **THEN** the command does not switch after creation for that invocation
-
-#### Scenario: Opt out of configured launch behavior
-- **WHEN** launch behavior is configured by default and the user invokes `arashi create <branch>` with a launch opt-out flag
-- **THEN** the command does not execute launch behavior for that invocation
-
 ### Requirement: Preserve current behavior when defaults are absent
 The system MUST preserve existing create behavior when new create default settings are not present in configuration, and editor-hosted invocations MUST fall back to no post-create defaults when no host-specific create defaults are configured.
 
@@ -61,6 +25,8 @@ The system MUST preserve existing create behavior when new create default settin
 #### Scenario: Editor host has no matching create defaults
 - **WHEN** the user runs `arashi create <branch>` from a supported editor host and the workspace does not define create defaults for that host
 - **THEN** the command does not apply generic create defaults and does not perform post-create switch or launch behavior unless explicitly requested by CLI flags
+
+## ADDED Requirements
 
 ### Requirement: Support editor-scoped create defaults
 The system SHALL allow workspace configuration to define create defaults scoped to supported editor hosts so extension-driven create flows can override generic terminal defaults.

--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/specs/vscode-command-integration/spec.md
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/specs/vscode-command-integration/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Pass editor host context for create invocations
+The extension SHALL pass its detected editor host context when invoking `arashi create` so the CLI can resolve editor-scoped create defaults without implying a launch override.
+
+#### Scenario: VS Code create passes VS Code host context
+- **WHEN** a user runs `arashi create` from the extension inside VS Code
+- **THEN** the extension invokes the CLI with create arguments that identify the host as VS Code for default-resolution purposes
+
+#### Scenario: Cursor create passes Cursor host context
+- **WHEN** a user runs `arashi create` from the extension inside Cursor
+- **THEN** the extension invokes the CLI with create arguments that identify the host as Cursor for default-resolution purposes
+
+#### Scenario: Unknown host omits create host context
+- **WHEN** a user runs `arashi create` from the extension in a compatible host that does not map to a supported editor-host identifier
+- **THEN** the extension invokes the CLI without editor-host context and without adding an IDE launch flag on behalf of the user

--- a/openspec/changes/archive/2026-04-17-create-extension-defaults/tasks.md
+++ b/openspec/changes/archive/2026-04-17-create-extension-defaults/tasks.md
@@ -1,0 +1,15 @@
+## 1. CLI create defaults
+
+- [x] 1.1 Extend Arashi config types, normalization, and schema output to support editor-scoped create defaults under the existing defaults tree.
+- [x] 1.2 Add create invocation support for editor-host context and update create default resolution so terminal invocations use generic defaults while editor-hosted invocations use host-specific defaults or no defaults.
+- [x] 1.3 Add CLI tests covering terminal precedence, editor-specific override precedence, and no-default fallback when an editor host has no configured create defaults.
+
+## 2. VS Code extension integration
+
+- [x] 2.1 Update the extension create argument builder and command handlers to pass the detected editor host when invoking `arashi create`.
+- [x] 2.2 Add extension tests covering VS Code, Cursor, and unknown-host create invocations so host context is passed only when supported.
+
+## 3. Docs and validation
+
+- [x] 3.1 Update CLI configuration guidance with examples for generic create defaults versus editor-scoped create defaults, and review whether companion docs need matching updates.
+- [x] 3.2 Run the relevant validation commands in `repos/arashi/` and `repos/arashi-vscode/`, then fix any failures introduced by the change.

--- a/openspec/specs/vscode-command-integration/spec.md
+++ b/openspec/specs/vscode-command-integration/spec.md
@@ -95,6 +95,21 @@ The extension SHALL invoke `arashi switch` with explicit worktree-path targeting
 - **WHEN** an extension switch flow invokes `arashi switch` for a selected worktree in VS Code, Cursor, or Kiro
 - **THEN** the extension still passes the matching host-specific IDE override together with the explicit path-targeting mode
 
+### Requirement: Pass editor host context for create invocations
+The extension SHALL pass its detected editor host context when invoking `arashi create` so the CLI can resolve editor-scoped create defaults without implying a launch override.
+
+#### Scenario: VS Code create passes VS Code host context
+- **WHEN** a user runs `arashi create` from the extension inside VS Code
+- **THEN** the extension invokes the CLI with create arguments that identify the host as VS Code for default-resolution purposes
+
+#### Scenario: Cursor create passes Cursor host context
+- **WHEN** a user runs `arashi create` from the extension inside Cursor
+- **THEN** the extension invokes the CLI with create arguments that identify the host as Cursor for default-resolution purposes
+
+#### Scenario: Unknown host omits create host context
+- **WHEN** a user runs `arashi create` from the extension in a compatible host that does not map to a supported editor-host identifier
+- **THEN** the extension invokes the CLI without editor-host context and without adding an IDE launch flag on behalf of the user
+
 ### Requirement: Register repository navigation commands in VS Code
 The extension SHALL register command-palette commands for opening the Arashi workspace root and related repositories in repo-focused editor windows, and SHALL reuse the same command handlers from tree-view interactions.
 


### PR DESCRIPTION
## Summary
- archive the completed `create-extension-defaults` change under `openspec/changes/archive/`
- sync the canonical `create-command-defaults` and `vscode-command-integration` specs with the implemented behavior
- document that extension-driven create can use editor-scoped defaults instead of inheriting terminal defaults

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/57, https://github.com/corwinm/arashi-vscode/pull/11
- Related issue: https://github.com/corwinm/arashi-arashi/issues/144

Closes #144