### PR TITLE
specs: archive default-branch status change

### DIFF
--- a/openspec/changes/archive/2026-04-17-status-show-default-diff/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-status-show-default-diff/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-17-status-show-default-diff/design.md
+++ b/openspec/changes/archive/2026-04-17-status-show-default-diff/design.md
@@ -1,0 +1,79 @@
+## Context
+
+`arashi status` already resolves and refreshes the current branch's upstream tracking ref before parsing `git status`, then renders that divergence on the Branch line. It does not currently compute whether the checked-out branch has fallen behind the repository's default branch, even though Arashi users often work on coordinated feature branches that can quietly drift behind `main` (or another default branch) across multiple repos.
+
+The CLI already has default-branch detection logic in `repos/arashi/src/lib/git.ts` and targeted remote-fetch logic in `repos/arashi/src/lib/git-remote.ts`. This change should build on those patterns instead of introducing an unrelated comparison path. The main constraint is that `arashi status` must remain useful when a repository has no resolvable default branch, is detached, or cannot refresh remote state.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show when the current branch is behind the repository's default branch during `arashi status`.
+- Keep the output concise and recognizable, matching the issue's requested `Default: 5 ↓` style.
+- Refresh the default-branch ref before comparing so the reported count is not based on stale remote state when a remote target is available.
+- Preserve existing repository status behavior when default-branch comparison is not possible.
+- Add tests for behind-default output, no-op cases, and comparison fallback behavior.
+
+**Non-Goals:**
+- Implement the future bulk command that updates repositories from their default branch.
+- Redesign the existing tracking-branch display on the Branch line.
+- Add new user-facing flags or configuration for enabling/disabling default-branch comparison in this change.
+- Surface a full ahead/behind matrix against both upstream and default branch in every output mode.
+
+## Decisions
+
+### 1. Model default-branch comparison separately from upstream tracking
+- **Decision:** Add a dedicated default-branch comparison field to `RepoStatus` rather than overloading `BranchTrackingInfo`.
+- **Rationale:** Upstream tracking and default-branch comparison answer different questions: one shows publish/sync state for the current branch, the other shows whether the branch has drifted behind the repo baseline. Keeping them separate avoids confusing the current Branch line and makes formatter logic clearer.
+- **Alternatives considered:**
+  - Reuse `BranchTrackingInfo` for both upstream and default branch data: rejected because it conflates two different refs and makes output ambiguous.
+  - Compute default divergence only in formatters: rejected because fetch/compare failures need structured state from repository status collection.
+
+### 2. Resolve a fetchable default-branch target, then compare `HEAD` against it
+- **Decision:** Add or extract a helper that resolves the default branch name together with its compare target, refreshes that ref when possible, and returns a comparison result suitable for status rendering.
+- **Rationale:** `getDefaultBranch()` already knows how to infer the branch name, while the remote helpers already know how to do targeted fetches. `arashi status` needs both pieces in one workflow so it can compare `HEAD` to an up-to-date default branch without duplicating resolution logic inside the command.
+- **Alternatives considered:**
+  - Compare only against the local default branch without fetching: rejected because it can silently report stale results.
+  - Always assume `origin/<default-branch>` exists: rejected because some repos may lack `origin` or have incomplete remote refs.
+
+### 3. Display default-branch drift on a dedicated `Default:` line
+- **Decision:** Default and verbose output should render default-branch drift as its own line, e.g. `Default: main [↓5]`, instead of overloading the existing Branch line.
+- **Rationale:** The Branch line already communicates the current branch and upstream tracking state. A separate line keeps the new signal readable, aligns with the issue's requested `Default:` wording, and leaves room for concise unavailable/warning states when needed.
+- **Alternatives considered:**
+  - Append default drift to the Branch line: rejected because it mixes two independent comparisons and makes warning states harder to read.
+  - Show default drift only in short mode or only when verbose: rejected because the main value is in ordinary `arashi status` usage.
+
+### 4. Show only behind-default counts by default
+- **Decision:** The new output should focus on how many commits the current branch is behind the default branch. If the current branch is current with or ahead of the default branch, the `Default:` line can be omitted unless a warning/unavailable state must be shown.
+- **Rationale:** Feature branches are usually ahead of the default branch by design, so showing both directions on every repo would create noise. The issue asks specifically for visibility into branches that are behind default.
+- **Alternatives considered:**
+  - Always show full ahead/behind counts: rejected as too noisy for routine status scans.
+  - Show only the default branch name with no count: rejected because the actionable information is the behind count.
+
+### 5. Treat default-branch comparison failures as non-fatal degradation
+- **Decision:** If default-branch resolution, refresh, or comparison fails, keep the rest of the repository status intact and surface a concise unavailable/warning state separate from hard repository errors.
+- **Rationale:** Users still need local file status and upstream-tracking info even when the extra default-branch comparison cannot be computed.
+- **Alternatives considered:**
+  - Fail the whole repository status when default comparison fails: rejected because it makes a supplemental signal too disruptive.
+  - Omit failures silently: rejected because it can make `no Default line` look the same as `up to date`.
+
+## Risks / Trade-offs
+
+- [Risk] Another per-repository fetch/compare step could slow `arashi status` noticeably. → Mitigation: skip comparison when the repository is detached or already on the default branch, and use a targeted fetch for just the default branch ref.
+- [Risk] Default-branch detection may not map cleanly to a remote ref in unusual repositories. → Mitigation: keep the comparison optional and model explicit unavailable states instead of forcing brittle assumptions.
+- [Risk] Extra output could make status feel noisier. → Mitigation: only show the `Default:` line when the branch is behind default or when comparison is unavailable and worth surfacing.
+- [Risk] Separate warning plumbing for upstream refresh and default comparison may complicate status rendering. → Mitigation: use structured status metadata so formatters branch on small, well-named states instead of parsing strings.
+
+## Migration Plan
+
+1. Add a shared helper for resolving and comparing the default branch target.
+2. Extend `RepoStatus` with structured default-branch comparison data.
+3. Update default, verbose, and short formatters to render behind-default indicators and unavailable states.
+4. Add unit tests for resolution/comparison logic and formatter coverage for new output.
+5. Run CLI validation in `repos/arashi` (`bun test`, `bun run lint`, `bun run build`).
+
+Rollback is straightforward: remove the new default-comparison field and formatter output, then restore the prior status-only behavior.
+
+## Open Questions
+
+- Whether the unavailable state should include the default branch name when known (for example `Default: main (unavailable)`) or use a shorter generic warning.
+- Whether short output should use `default↓5`, `main↓5`, or another compact token for the new signal.

--- a/openspec/changes/archive/2026-04-17-status-show-default-diff/proposal.md
+++ b/openspec/changes/archive/2026-04-17-status-show-default-diff/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`arashi status` already helps users see whether each repository is clean, dirty, or diverged from its tracking branch, but it does not show whether a feature branch has fallen behind the repository's default branch. That leaves users without an easy way to spot when a coordinated feature needs to be rebased or updated across repos before drift becomes painful.
+
+## What Changes
+
+- Update `arashi status` to compare the current branch against each repository's default branch in addition to the existing tracking-branch summary.
+- Show default-branch divergence inline in status output with a concise indicator such as `Default: 5 ↓` when the current branch is behind the default branch.
+- Keep the output useful when the default branch cannot be resolved or refreshed, preserving the rest of the repository status instead of failing the command.
+- Add tests covering clean/default-up-to-date repositories, repositories behind the default branch, and fallback behavior when default-branch comparison is unavailable.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `status-command`: Extend `arashi status` requirements so repository status output includes divergence from the repo's default branch, not just the configured tracking branch.
+
+## Impact
+
+- Affected repo: `repos/arashi`.
+- Affected code: `src/commands/status.ts`, shared git/default-branch helpers, and status command tests.
+- User-visible behavior: `arashi status` output gains default-branch divergence information.
+- Follow-up review: confirm whether `repos/arashi-docs/` or `repos/arashi-skills/` need command-output examples updated after implementation.

--- a/openspec/changes/archive/2026-04-17-status-show-default-diff/specs/status-command/spec.md
+++ b/openspec/changes/archive/2026-04-17-status-show-default-diff/specs/status-command/spec.md
@@ -1,36 +1,4 @@
-# status-command Specification
-
-## Purpose
-TBD - created by syncing change status-fetch. Update Purpose after archive.
-## Requirements
-### Requirement: Refresh tracked remote state before reporting branch divergence
-The system SHALL refresh the resolved remote-tracking branch for each locally present repository before `arashi status` reports ahead/behind information.
-
-#### Scenario: Repository has a resolvable upstream branch
-- **WHEN** the user runs `arashi status` for a repository whose current branch maps to a remote-tracking branch
-- **THEN** the command runs a targeted `git fetch` for that tracking branch before parsing branch divergence output
-- **AND** the reported ahead/behind counts reflect the refreshed remote-tracking ref
-
-#### Scenario: Repository has no remote-tracking target
-- **WHEN** the user runs `arashi status` for a repository that has no configured remote, no upstream, or no resolvable branch target
-- **THEN** the command skips the remote refresh for that repository
-- **AND** the command still reports the repository's local branch and working-tree status
-
-### Requirement: Preserve local status when remote refresh fails
-The system MUST continue reporting local repository status when the remote refresh step fails. When the failure indicates that the resolved remote branch ref does not exist, the system MUST surface that condition inline on the branch display instead of showing the generic stale remote-tracking warning. For other remote refresh failures, the system MUST continue to indicate that remote-tracking information may be stale.
-
-#### Scenario: Fetch fails for a reachable local repository
-- **WHEN** the user runs `arashi status` and the repository's targeted `git fetch` fails because of network, authentication, or remote command errors other than a missing remote ref
-- **THEN** the command still reports the repository's local clean/dirty status
-- **AND** the command indicates that remote-tracking information could not be refreshed for that repository
-- **AND** the fetch failure is not treated as a missing-repository or git-status execution failure
-
-#### Scenario: Resolved remote branch does not exist on the remote
-- **WHEN** the user runs `arashi status` and the targeted `git fetch` fails because the resolved `refs/heads/<branch>` does not exist on the remote
-- **THEN** the command still reports the repository's local clean/dirty status
-- **AND** the Branch line shows the local branch followed by an inline warning in the remote position indicating that the remote ref could not be found
-- **AND** the Branch line is rendered as a warning rather than as a normal clean/dirty branch line
-- **AND** the command does not print the generic `Remote tracking may be stale` warning for that repository
+## ADDED Requirements
 
 ### Requirement: Refresh default-branch state before reporting behind-default status
 The system SHALL resolve each repository's default branch and refresh the compare target before `arashi status` reports whether the current branch is behind that default branch.
@@ -77,4 +45,3 @@ The system MUST continue reporting local repository status when default-branch c
 - **WHEN** the user runs `arashi status` for a repository whose default branch cannot be resolved to a comparison target
 - **THEN** the command skips default-branch comparison for that repository
 - **AND** the command still reports the repository's local branch and working-tree status without a misleading behind-default indicator
-

--- a/openspec/changes/archive/2026-04-17-status-show-default-diff/tasks.md
+++ b/openspec/changes/archive/2026-04-17-status-show-default-diff/tasks.md
@@ -1,0 +1,18 @@
+## 1. Resolve and compare the default branch target
+
+- [x] 1.1 Add a shared helper in `repos/arashi` that resolves a repository's default branch into a comparison target and refreshes it when a remote ref is available
+- [x] 1.2 Implement behind-default comparison logic that compares `HEAD` against the resolved default branch and returns structured status for behind, skipped, and unavailable states
+- [x] 1.3 Extend status data types to carry default-branch comparison results separately from upstream tracking and hard repository errors
+
+## 2. Render default-branch drift in `arashi status`
+
+- [x] 2.1 Update repository status collection to run default-branch comparison only when it is applicable and to preserve existing local status collection when comparison is skipped or unavailable
+- [x] 2.2 Update default and verbose status output to show a dedicated `Default:` line when the current branch is behind the repo default branch and to surface unavailable comparison states concisely
+- [x] 2.3 Update short status output to include a compact behind-default indicator without obscuring the existing branch and clean/dirty summary
+
+## 3. Verify behavior and review follow-up docs
+
+- [x] 3.1 Add unit tests for default-branch target resolution, behind-default comparisons, skipped cases, and unavailable comparison fallbacks
+- [x] 3.2 Add formatter tests covering default, verbose, and short output when a branch is behind default and when comparison is unavailable
+- [x] 3.3 Run `bun test`, `bun run lint`, and `bun run build` in `repos/arashi`
+- [x] 3.4 Review whether `repos/arashi-docs/` or `repos/arashi-skills/` need follow-up updates for the new `arashi status` output examples


### PR DESCRIPTION
## Summary
- archive the completed OpenSpec change for default-branch drift in status output
- sync the new status-command requirements into the main spec
- preserve the archived proposal, design, spec delta, and tasks for reference

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi/pull/58
- Related issue: https://github.com/corwinm/arashi-arashi/issues/147

Closes #147