### PR TITLE
specs: archive VS Code sibling worktree indentation change

### DIFF
--- a/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/design.md
+++ b/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The Arashi VS Code extension builds a tree view that groups top-level worktrees and nests related child repositories underneath each worktree. The reported bug is that a modified child repository in a sibling worktree appears to lose the expected indentation, which points to a VS Code tree-item formatting or layout issue rather than a discovery issue.
+
+The underlying worktree grouping logic already models parent worktrees and child repositories separately, so the fix should preserve existing command wiring, worktree grouping, and status text while making the visual hierarchy stable.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep child repositories visually nested under their parent worktree for both current and sibling worktrees.
+- Preserve modified-state information without making a child entry appear like a top-level item.
+- Add regression tests that cover sibling worktrees with modified child repositories.
+
+**Non-Goals:**
+- Redesign the overall worktree panel information architecture.
+- Change CLI JSON contracts or worktree discovery behavior.
+- Introduce new icons, assets, or external dependencies.
+
+## Decisions
+
+### Treat this as a VS Code tree-item formatting issue first
+Implementation should start by inspecting the TreeItem fields that affect how VS Code lays out nested repository entries, especially the interaction between label, description, tooltip, and icon metadata for modified child repositories. The fix should target whichever presentation detail causes VS Code to render a modified child entry as if it were not nested.
+
+**Rationale:** The issue report describes missing indentation specifically, and the current grouping model already preserves parent-child relationships. That makes a formatting problem in VS Code's rendering path more likely than a problem with worktree discovery.
+
+**Alternative considered:** Change icon choices first. Icons may still contribute to the final appearance, but the reported symptom is whitespace and indentation, so the design should not assume icon changes are the primary fix before the formatting issue is confirmed.
+
+### Limit the change to presentation-layer code
+The implementation should stay in `src/worktrees/provider.ts` and the related presentation tests unless a failing test proves the grouping model is also incorrect.
+
+**Rationale:** The issue report describes inconsistent alignment, and the existing presentation/grouping code already tracks child repositories separately from top-level worktrees. A small presentation-focused fix in the VS Code-facing rendering layer reduces risk.
+
+**Alternative considered:** Rework worktree grouping or add new metadata from the CLI. This would increase scope without strong evidence that discovery is the root cause.
+
+### Add regression coverage at the tree rendering boundary
+Tests should verify that sibling worktrees with modified child repositories still render nested child items and preserve the expected indentation and formatting in the tree.
+
+**Rationale:** The bug is user-visible in the tree view, so coverage should exercise the rendered panel model rather than only lower-level string helpers.
+
+## Risks / Trade-offs
+
+- **Formatting behavior may be hard to reproduce outside VS Code** → Add focused tests around the rendered tree-item model and manually verify the panel in VS Code if needed.
+- **Root cause may be broader than a single TreeItem field** → Inspect label, description, tooltip, and icon-related metadata together before widening the change.
+- **Theme-specific rendering differences may remain** → Prefer minimal, standard TreeItem configuration so the panel relies on VS Code defaults as much as possible.
+
+## Migration Plan
+
+- No data migration is required.
+- Ship as a normal extension update.
+- If the visual result regresses, revert the presentation-layer formatting change and restore the previous node rendering behavior.
+
+## Open Questions
+
+- Confirm during implementation which TreeItem property or combination of properties triggers the indentation problem in VS Code.

--- a/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/proposal.md
+++ b/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The VS Code worktree panel currently renders sibling worktrees inconsistently when a child repository has local modifications. A modified child repo can appear visually misaligned with other nested entries, which makes the worktree hierarchy harder to scan and breaks parity with the active worktree presentation.
+
+## What Changes
+
+- Adjust VS Code worktree panel presentation so child repositories remain visually nested under their parent worktree regardless of whether the worktree is current or a sibling.
+- Ensure modified-state indicators for child repositories do not break alignment or make a child entry appear like a top-level item.
+- Add regression coverage for sibling worktrees that include modified child repositories.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `vscode-worktree-panel`: refine worktree panel rendering requirements so sibling worktrees and their modified child repositories keep consistent hierarchical alignment.
+
+## Impact
+
+- Affected repo: `repos/arashi-vscode`
+- Likely affected areas: `src/worktrees/provider.ts`, `src/worktrees/presentation.ts`, and panel-related tests
+- User-visible impact: clearer, consistent worktree hierarchy in the VS Code extension panel

--- a/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/specs/vscode-worktree-panel/spec.md
+++ b/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/specs/vscode-worktree-panel/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Display Arashi worktrees with status metadata
+The extension SHALL provide a worktree panel that groups discovered worktrees by related repository context and lists each worktree with branch identity, path, git-change status indicators, and whether the entry belongs to the current workspace or a sibling worktree. Child repositories nested under a worktree SHALL remain visually distinguishable from top-level worktree entries even when a child repository has local modifications.
+
+#### Scenario: Repo-aware worktrees are available
+- **WHEN** the worktree panel is opened in a configured Arashi workspace
+- **THEN** the panel displays related repository entries and the worktrees associated with each repository, including branch, relationship, and status metadata for each worktree entry
+
+#### Scenario: Parent and current repo context are visible
+- **WHEN** the current window belongs to a child repository or a sibling worktree
+- **THEN** the panel labels the current repository context and identifies the workspace root or parent repository distinctly from other child repositories
+
+#### Scenario: Modified child repository in a sibling worktree preserves hierarchy
+- **WHEN** a sibling worktree contains a child repository with local modifications
+- **THEN** the modified child repository is rendered as a nested child of that sibling worktree rather than appearing visually aligned with top-level worktree items
+
+#### Scenario: No worktrees are available
+- **WHEN** the worktree panel is opened and no Arashi or sibling worktrees are discovered
+- **THEN** the panel shows an explicit empty state with guidance for creating a worktree or using command-palette flows for additional setup

--- a/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/tasks.md
+++ b/openspec/changes/archive/2026-04-21-fix-vscode-sibling-worktree-indentation/tasks.md
@@ -1,0 +1,14 @@
+## 1. Reproduce and cover the panel regression
+
+- [x] 1.1 Add or update a tree/presentation test that models a sibling worktree with a modified child repository.
+- [x] 1.2 Assert that the modified child repository is still rendered as a nested child entry and keeps modified-state text visible.
+
+## 2. Stabilize repository node presentation
+
+- [x] 2.1 Update the VS Code worktree tree-item rendering so child repository nodes use consistent structural iconography across clean and modified states.
+- [x] 2.2 Preserve current-vs-child context and modified-state information in descriptions/tooltips after the icon treatment change.
+
+## 3. Validate the extension behavior
+
+- [x] 3.1 Run the relevant `repos/arashi-vscode` unit/integration tests covering the worktree panel.
+- [x] 3.2 Run `bun run build` in `repos/arashi-vscode` to confirm the extension still compiles cleanly.

--- a/openspec/specs/vscode-worktree-panel/spec.md
+++ b/openspec/specs/vscode-worktree-panel/spec.md
@@ -4,7 +4,7 @@
 TBD - created by archiving change create-vscode-plugin. Update Purpose after archive.
 ## Requirements
 ### Requirement: Display Arashi worktrees with status metadata
-The extension SHALL provide a worktree panel that groups discovered worktrees by related repository context and lists each worktree with branch identity, path, git-change status indicators, and whether the entry belongs to the current workspace or a sibling worktree.
+The extension SHALL provide a worktree panel that groups discovered worktrees by related repository context and lists each worktree with branch identity, path, git-change status indicators, and whether the entry belongs to the current workspace or a sibling worktree. Child repositories nested under a worktree SHALL remain visually distinguishable from top-level worktree entries even when a child repository has local modifications.
 
 #### Scenario: Repo-aware worktrees are available
 - **WHEN** the worktree panel is opened in a configured Arashi workspace
@@ -13,6 +13,10 @@ The extension SHALL provide a worktree panel that groups discovered worktrees by
 #### Scenario: Parent and current repo context are visible
 - **WHEN** the current window belongs to a child repository or a sibling worktree
 - **THEN** the panel labels the current repository context and identifies the workspace root or parent repository distinctly from other child repositories
+
+#### Scenario: Modified child repository in a sibling worktree preserves hierarchy
+- **WHEN** a sibling worktree contains a child repository with local modifications
+- **THEN** the modified child repository is rendered as a nested child of that sibling worktree rather than appearing visually aligned with top-level worktree items
 
 #### Scenario: No worktrees are available
 - **WHEN** the worktree panel is opened and no Arashi or sibling worktrees are discovered


### PR DESCRIPTION
## Summary
- archive the completed OpenSpec change for VS Code sibling worktree indentation
- sync the vscode-worktree-panel main spec with the new modified-child hierarchy scenario
- keep the archived proposal, design, spec delta, and task artifacts together

## Related
- Companion implementation/spec PRs: https://github.com/corwinm/arashi-vscode/pull/12
- Related issue: https://github.com/corwinm/arashi-arashi/issues/156

Closes #156
