### PR TITLE
docs: propose remove dry-run preview

### DIFF
--- a/openspec/changes/add-remove-dry-run/.openspec.yaml
+++ b/openspec/changes/add-remove-dry-run/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/add-remove-dry-run/design.md
+++ b/openspec/changes/add-remove-dry-run/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`arashi remove` already discovers worktrees, filters prunable records, checks dirty state, asks for confirmation unless forced, resolves branch presence across configured repositories, executes remove lifecycle hooks, removes worktrees, and deletes local branches. The new dry-run mode should reuse the same discovery and planning path so the preview matches the later mutating run, while making the mutation boundary explicit and testable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce a faithful non-mutating plan for branch-name, path-targeted, forced, keep-worktrees, keep-branches, and JSON remove invocations.
+- Surface dirty/blocking worktrees and skipped/missing repositories before users approve destructive cleanup.
+- Show configured remove hooks that would be considered, without executing hook scripts during preview.
+- Keep JSON stdout isolated and parseable for agents.
+- Update CLI docs, docs site, and skill guidance so users know when to preview first.
+
+**Non-Goals:**
+
+- Changing the safety semantics of mutating `arashi remove`.
+- Adding remote branch deletion or remote cleanup preview.
+- Running hook scripts in any dry-run mode.
+- Making interactive selection available in `--json` mode; JSON still requires explicit target input.
+
+## Decisions
+
+### Build an explicit removal plan before mutation
+
+Create a plan object after target resolution, dirty checks, branch presence checks, and target repository derivation. The plan should include planned worktree remove operations, planned branch deletes, skipped main worktrees, missing branches, dirty blockers/details, the effective option flags, and hook discovery context. The mutating path can then execute from the plan instead of recomputing separate data.
+
+Alternative considered: formatting the existing `RemovalSummary` before mutation by marking operations as pending. That keeps the diff smaller, but the summary type currently represents completed operations and success counts; overloading it for preview risks confusing dry-run output with executed results.
+
+### Keep dry-run non-interactive except for target selection
+
+Human `arashi remove --dry-run` without a target may still use the existing interactive worktree selector, because selection itself is not destructive and is required to know what the user wants to preview. After selection, dry-run must not ask the destructive confirmation prompt even when `--force` is absent.
+
+JSON `arashi remove --dry-run --json` should require an explicit target, matching the current JSON non-interactive contract.
+
+### Discover but do not execute hooks during preview
+
+Dry-run should resolve `pre-remove` and `post-remove` hooks for the same target repositories and report whether hooks are configured, skipped, disabled, or invalid when this information is available without executing scripts. It must not run hook scripts or depend on hook exit status, because hook execution can mutate external systems.
+
+### Treat dirty state as preview information, not a dry-run failure by itself
+
+When the normal dirty check is enabled, dry-run should include dirty details and label those worktrees as blockers that would require user confirmation or an override path in a real remove. Because no mutation occurs, the preview can still exit successfully when the plan was produced. Structural errors such as missing targets or invalid config should still fail as they do today.
+
+### Represent keep flags in the plan
+
+`--keep-worktrees` should suppress planned worktree removals and show branch deletion/detach implications. `--keep-branches` should suppress planned branch deletes. Supplying both keep flags should produce a no-op preview that explicitly says no destructive operation would be performed.
+
+## Risks / Trade-offs
+
+- Preview and mutation drift → Reuse the same target resolution and planning helpers for both paths, and add tests that compare planned operations to mutating summaries in fixture workspaces.
+- Hook context may be incomplete without execution → Report discovery/configuration context only and document that hook success/failure is known only during real removal.
+- Output shape churn for existing JSON consumers → Add dry-run fields under a command-specific plan data object while preserving current mutating remove JSON behavior.
+- Dirty worktree terminology can imply failure → Use explicit `blockers` / `warnings` language in JSON and clear human headings such as “Would be blocked without confirmation/force”.
+
+## Migration Plan
+
+1. Add tests describing dry-run planning and non-mutation behavior.
+2. Implement plan construction and dry-run formatting in `repos/arashi`.
+3. Update docs and skill references.
+4. Validate CLI, docs, and skill package changes before opening implementation PRs.

--- a/openspec/changes/add-remove-dry-run/proposal.md
+++ b/openspec/changes/add-remove-dry-run/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`arashi remove` can delete coordinated worktrees and local branches across every configured repository. Users and agents need a non-mutating preview that shows the exact cleanup plan, blockers, and hook context before approving destructive removal.
+
+## What Changes
+
+- Add `arashi remove --dry-run` to resolve the same target selection, dirty checks, branch presence, skipped main worktrees, and remove hook discovery as a real remove run without removing worktrees, deleting branches, detaching worktrees, or executing hooks.
+- Clearly mark human output as a preview and list the worktree removals, branch deletions, skipped/missing repos, dirty blockers, and configured `pre-remove` / `post-remove` hooks that would be involved.
+- Add `arashi remove --dry-run --json` as a structured removal plan suitable for agents and automation.
+- Document the workflow in CLI docs, docs site command reference, and Arashi skill guidance.
+- No breaking changes: existing `arashi remove` mutation behavior remains unchanged when `--dry-run` is not supplied.
+
+## Capabilities
+
+### New Capabilities
+- `remove-dry-run-preview`: Non-mutating `arashi remove` preview behavior, including human preview output, operation planning, blockers, option effects, and hook context.
+
+### Modified Capabilities
+- `machine-readable-cli-output`: Extend the existing JSON contract with a structured `arashi remove --dry-run --json` removal plan.
+
+## Impact
+
+- `repos/arashi`: remove command options, planning helpers, summary/JSON formatting, and unit/integration tests.
+- `repos/arashi-docs`: command reference updates for dry-run preview usage and JSON automation examples.
+- `repos/arashi-skills`: command guidance updates so agents prefer dry-run before destructive cleanup when uncertainty exists.

--- a/openspec/changes/add-remove-dry-run/specs/machine-readable-cli-output/spec.md
+++ b/openspec/changes/add-remove-dry-run/specs/machine-readable-cli-output/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Remove dry-run JSON results
+
+The Arashi CLI SHALL provide structured JSON results for `arashi remove --dry-run --json` that describe a non-mutating removal plan in the standard JSON envelope.
+
+#### Scenario: Dry-run remove JSON succeeds
+- **WHEN** a user runs `arashi remove <target> --dry-run --json`
+- **THEN** stdout contains exactly one valid JSON envelope with `ok: true` and `command: "remove"`
+- **AND** the data object identifies the invocation as dry-run preview mode
+- **AND** the data object includes planned worktree removals, planned branch deletions, skipped main worktrees, missing branches, blockers or dirty details, hook preview context, effective options, and totals
+- **AND** no human-readable preview text is mixed into stdout
+
+#### Scenario: Dry-run remove JSON requires explicit target
+- **WHEN** a user runs `arashi remove --dry-run --json` without a target and interactive selection would be required
+- **THEN** stdout contains exactly one valid JSON error envelope
+- **AND** the error explains that an explicit target is required for JSON mode
+- **AND** no prompt is shown
+
+#### Scenario: Dry-run remove JSON reports no-op keep flags
+- **WHEN** a user runs `arashi remove <target> --dry-run --json --keep-worktrees --keep-branches`
+- **THEN** stdout contains exactly one valid JSON envelope with `ok: true`
+- **AND** the plan totals show zero planned worktree removals and zero planned branch deletions
+- **AND** the effective options show both keep flags were supplied
+
+#### Scenario: Dry-run remove JSON is non-mutating
+- **WHEN** a user runs `arashi remove <target> --dry-run --json`
+- **THEN** the JSON plan describes pending operations only
+- **AND** no operation in the plan is reported as successfully executed
+- **AND** worktrees, branches, and hooks remain unmodified by the preview

--- a/openspec/changes/add-remove-dry-run/specs/remove-dry-run-preview/spec.md
+++ b/openspec/changes/add-remove-dry-run/specs/remove-dry-run-preview/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Remove dry-run preview mode
+
+The system SHALL provide `arashi remove --dry-run` as a non-mutating preview mode that resolves the requested removal target and reports the operations that would be attempted without removing worktrees, deleting branches, detaching worktrees, or executing lifecycle hooks.
+
+#### Scenario: Branch-targeted dry-run preserves worktrees and branches
+- **WHEN** a user runs `arashi remove <branch> --dry-run`
+- **THEN** the command reports the worktrees and local branches that would be removed for `<branch>`
+- **AND** no worktree directory is removed
+- **AND** no local branch is deleted
+
+#### Scenario: Path-targeted dry-run previews selected worktree
+- **WHEN** a user runs `arashi remove <worktree-path> --dry-run --path`
+- **THEN** the command reports the matching non-main worktree removal and associated branch deletion plan
+- **AND** the target worktree remains present after the command exits
+
+#### Scenario: Dry-run with both keep flags is a no-op preview
+- **WHEN** a user runs `arashi remove <branch> --dry-run --keep-worktrees --keep-branches`
+- **THEN** the command reports that no destructive operations would be performed
+- **AND** the command exits successfully without mutation
+
+### Requirement: Human preview output
+
+Human dry-run output SHALL clearly identify itself as a preview and SHALL distinguish planned worktree removals, planned branch deletions, skipped repositories, missing branches, dirty or blocking worktrees, and option effects.
+
+#### Scenario: Preview is clearly labeled
+- **WHEN** a user runs `arashi remove <branch> --dry-run`
+- **THEN** the output includes a preview heading such as `Dry run` or `Preview`
+- **AND** the output does not use success wording that implies worktrees or branches were actually removed
+
+#### Scenario: Preview explains keep-worktrees behavior
+- **WHEN** a user runs `arashi remove <branch> --dry-run --keep-worktrees`
+- **THEN** the output shows that worktree directories would be kept
+- **AND** the output shows any branch deletions that would still be attempted
+
+#### Scenario: Preview explains keep-branches behavior
+- **WHEN** a user runs `arashi remove <branch> --dry-run --keep-branches`
+- **THEN** the output shows that local branches would be kept
+- **AND** the output shows any worktree removals that would still be attempted
+
+### Requirement: Dry-run blockers and dirty context
+
+Dry-run mode SHALL include blocker and dirty-state context that a real remove run would consider before mutation, while still avoiding destructive confirmation prompts in preview mode.
+
+#### Scenario: Dirty worktree appears in preview
+- **WHEN** a target worktree has uncommitted changes and the user runs `arashi remove <branch> --dry-run`
+- **THEN** the preview identifies the dirty worktree and summarizes available dirty details
+- **AND** the command does not prompt for destructive confirmation
+- **AND** the dirty worktree remains unchanged
+
+#### Scenario: Missing branches appear in preview
+- **WHEN** a branch target exists in some configured repositories but not others
+- **THEN** the preview lists repositories where the local branch is missing
+- **AND** planned branch deletions include only repositories where the branch exists
+
+#### Scenario: Main worktrees remain skipped
+- **WHEN** the target resolution includes a main worktree that cannot be removed
+- **THEN** dry-run output reports that the main worktree would be skipped
+- **AND** the main worktree remains unchanged
+
+### Requirement: Dry-run lifecycle hook context
+
+Dry-run mode SHALL report remove lifecycle hook context that can be determined safely without executing hook scripts.
+
+#### Scenario: Configured hooks are previewed but not executed
+- **WHEN** `pre-remove` or `post-remove` hooks are configured for a target repository and the user runs `arashi remove <branch> --dry-run`
+- **THEN** the preview identifies configured remove hooks or hook scopes that would be considered by a real removal
+- **AND** no hook script is executed
+
+#### Scenario: Hook absence is previewed
+- **WHEN** no remove lifecycle hooks are configured for a target repository and the user runs dry-run preview
+- **THEN** the preview indicates that no remove hooks are configured or omits hook execution from the planned operations without treating absence as an error
+
+### Requirement: Dry-run validation coverage
+
+The system SHALL include automated tests proving that dry-run plans match the requested target and do not mutate repositories.
+
+#### Scenario: Tests prove worktree non-mutation
+- **WHEN** the dry-run test fixture creates removable worktrees and branches
+- **THEN** tests assert those worktrees and branches still exist after `arashi remove --dry-run`
+
+#### Scenario: Tests cover option-specific plans
+- **WHEN** tests exercise `--dry-run` with `--keep-worktrees`, `--keep-branches`, `--path`, and `--json`
+- **THEN** each test asserts the resulting plan includes only operations allowed by the selected options

--- a/openspec/changes/add-remove-dry-run/tasks.md
+++ b/openspec/changes/add-remove-dry-run/tasks.md
@@ -24,4 +24,4 @@
 - [x] 4.1 Run `bun run lint`, `bun run test`, and `bun run build` in `repos/arashi`.
 - [x] 4.2 Run `bun run validate` in `repos/arashi-docs`.
 - [x] 4.3 Run the arashi-skills validation command if present, or inspect/package the affected skill files according to existing repo scripts.
-- [ ] 4.4 Open focused, cross-linked implementation PRs for `corwinm/arashi`, `corwinm/arashi-docs`, and `corwinm/arashi-skills` as needed, then update the meta/spec PR with the related PR set.
+- [x] 4.4 Open focused, cross-linked implementation PRs for `corwinm/arashi`, `corwinm/arashi-docs`, and `corwinm/arashi-skills` as needed, then update the meta/spec PR with the related PR set.

--- a/openspec/changes/add-remove-dry-run/tasks.md
+++ b/openspec/changes/add-remove-dry-run/tasks.md
@@ -1,0 +1,27 @@
+## 1. CLI Planning and Tests
+
+- [ ] 1.1 Add strict TDD coverage for `arashi remove --dry-run` branch-targeted preview and prove worktrees/branches remain after the command.
+- [ ] 1.2 Add tests for path-targeted dry-run, dirty worktree preview details, missing branch/skipped main reporting, and `--keep-worktrees` / `--keep-branches` plan effects.
+- [ ] 1.3 Add JSON-mode tests for `arashi remove <target> --dry-run --json`, explicit-target errors, stdout isolation, and no-op keep-flag plans.
+- [ ] 1.4 Add hook preview tests proving configured remove hooks are reported but not executed during dry-run.
+
+## 2. CLI Implementation
+
+- [ ] 2.1 Add the `--dry-run` option to `arashi remove` command parsing and `RemoveCommandOptions`.
+- [ ] 2.2 Extract reusable removal-plan construction after target resolution, dirty checks, branch presence checks, skipped-main detection, and hook target discovery.
+- [ ] 2.3 Implement non-mutating dry-run execution that returns after plan formatting and bypasses destructive confirmation prompts, hook execution, worktree removal, worktree detach, and branch deletion.
+- [ ] 2.4 Add human preview formatting with explicit preview headings, planned operations, blockers, skipped/missing repositories, option effects, and hook context.
+- [ ] 2.5 Add JSON preview formatting under the standard envelope while preserving existing mutating remove JSON output shape.
+
+## 3. Documentation and Skill Guidance
+
+- [ ] 3.1 Update `repos/arashi/docs/commands/remove.md` with dry-run usage, examples, and safety notes.
+- [ ] 3.2 Update `repos/arashi-docs/docs/commands/remove.md` with dry-run and JSON preview examples.
+- [ ] 3.3 Update `repos/arashi-skills/skills/arashi/references/commands.md` and hook guidance where appropriate so agents preview uncertain destructive cleanup first.
+
+## 4. Validation and PR Choreography
+
+- [ ] 4.1 Run `bun run lint`, `bun run test`, and `bun run build` in `repos/arashi`.
+- [ ] 4.2 Run `bun run validate` in `repos/arashi-docs`.
+- [ ] 4.3 Run the arashi-skills validation command if present, or inspect/package the affected skill files according to existing repo scripts.
+- [ ] 4.4 Open focused, cross-linked implementation PRs for `corwinm/arashi`, `corwinm/arashi-docs`, and `corwinm/arashi-skills` as needed, then update the meta/spec PR with the related PR set.

--- a/openspec/changes/add-remove-dry-run/tasks.md
+++ b/openspec/changes/add-remove-dry-run/tasks.md
@@ -1,27 +1,27 @@
 ## 1. CLI Planning and Tests
 
-- [ ] 1.1 Add strict TDD coverage for `arashi remove --dry-run` branch-targeted preview and prove worktrees/branches remain after the command.
-- [ ] 1.2 Add tests for path-targeted dry-run, dirty worktree preview details, missing branch/skipped main reporting, and `--keep-worktrees` / `--keep-branches` plan effects.
-- [ ] 1.3 Add JSON-mode tests for `arashi remove <target> --dry-run --json`, explicit-target errors, stdout isolation, and no-op keep-flag plans.
-- [ ] 1.4 Add hook preview tests proving configured remove hooks are reported but not executed during dry-run.
+- [x] 1.1 Add strict TDD coverage for `arashi remove --dry-run` branch-targeted preview and prove worktrees/branches remain after the command.
+- [x] 1.2 Add tests for path-targeted dry-run, dirty worktree preview details, missing branch/skipped main reporting, and `--keep-worktrees` / `--keep-branches` plan effects.
+- [x] 1.3 Add JSON-mode tests for `arashi remove <target> --dry-run --json`, explicit-target errors, stdout isolation, and no-op keep-flag plans.
+- [x] 1.4 Add hook preview tests proving configured remove hooks are reported but not executed during dry-run.
 
 ## 2. CLI Implementation
 
-- [ ] 2.1 Add the `--dry-run` option to `arashi remove` command parsing and `RemoveCommandOptions`.
-- [ ] 2.2 Extract reusable removal-plan construction after target resolution, dirty checks, branch presence checks, skipped-main detection, and hook target discovery.
-- [ ] 2.3 Implement non-mutating dry-run execution that returns after plan formatting and bypasses destructive confirmation prompts, hook execution, worktree removal, worktree detach, and branch deletion.
-- [ ] 2.4 Add human preview formatting with explicit preview headings, planned operations, blockers, skipped/missing repositories, option effects, and hook context.
-- [ ] 2.5 Add JSON preview formatting under the standard envelope while preserving existing mutating remove JSON output shape.
+- [x] 2.1 Add the `--dry-run` option to `arashi remove` command parsing and `RemoveCommandOptions`.
+- [x] 2.2 Extract reusable removal-plan construction after target resolution, dirty checks, branch presence checks, skipped-main detection, and hook target discovery.
+- [x] 2.3 Implement non-mutating dry-run execution that returns after plan formatting and bypasses destructive confirmation prompts, hook execution, worktree removal, worktree detach, and branch deletion.
+- [x] 2.4 Add human preview formatting with explicit preview headings, planned operations, blockers, skipped/missing repositories, option effects, and hook context.
+- [x] 2.5 Add JSON preview formatting under the standard envelope while preserving existing mutating remove JSON output shape.
 
 ## 3. Documentation and Skill Guidance
 
-- [ ] 3.1 Update `repos/arashi/docs/commands/remove.md` with dry-run usage, examples, and safety notes.
-- [ ] 3.2 Update `repos/arashi-docs/docs/commands/remove.md` with dry-run and JSON preview examples.
-- [ ] 3.3 Update `repos/arashi-skills/skills/arashi/references/commands.md` and hook guidance where appropriate so agents preview uncertain destructive cleanup first.
+- [x] 3.1 Update `repos/arashi/docs/commands/remove.md` with dry-run usage, examples, and safety notes.
+- [x] 3.2 Update `repos/arashi-docs/docs/commands/remove.md` with dry-run and JSON preview examples.
+- [x] 3.3 Update `repos/arashi-skills/skills/arashi/references/commands.md` and hook guidance where appropriate so agents preview uncertain destructive cleanup first.
 
 ## 4. Validation and PR Choreography
 
-- [ ] 4.1 Run `bun run lint`, `bun run test`, and `bun run build` in `repos/arashi`.
-- [ ] 4.2 Run `bun run validate` in `repos/arashi-docs`.
-- [ ] 4.3 Run the arashi-skills validation command if present, or inspect/package the affected skill files according to existing repo scripts.
+- [x] 4.1 Run `bun run lint`, `bun run test`, and `bun run build` in `repos/arashi`.
+- [x] 4.2 Run `bun run validate` in `repos/arashi-docs`.
+- [x] 4.3 Run the arashi-skills validation command if present, or inspect/package the affected skill files according to existing repo scripts.
 - [ ] 4.4 Open focused, cross-linked implementation PRs for `corwinm/arashi`, `corwinm/arashi-docs`, and `corwinm/arashi-skills` as needed, then update the meta/spec PR with the related PR set.


### PR DESCRIPTION
## Summary
- Proposes and tracks implementation for `arashi remove --dry-run`, a non-mutating preview mode for destructive worktree/branch cleanup.
- Defines dry-run behavior for target resolution, planned operations, dirty/blocker state, branch deletion plans, confirmation suppression, and lifecycle hook discard reporting.
- Adds machine-readable JSON preview requirements under the existing CLI JSON output contract.
- Implementation tasks are complete; child PRs were merged green.

## Related PRs
- CLI implementation: https://github.com/corwinm/arashi/pull/78 — merged
- Docs: https://github.com/corwinm/arashi-docs/pull/35 — merged
- Skills guidance: https://github.com/corwinm/arashi-skills/pull/29 — merged

Closes #182

## Validation
- `openspec validate add-remove-dry-run`
- `repos/arashi`: `bun run format:check`
- `repos/arashi`: `bun run lint` (exits 0; remaining warnings are pre-existing/unrelated)
- `repos/arashi`: `bun test tests/integration/remove.dry-run.test.ts`
- `repos/arashi`: `bun run test` (762 passing)
- `repos/arashi`: `bun run build`
- `repos/arashi` CI: Quality Checks, Test ubuntu/windows, Build ubuntu/macos/windows, Validate ubuntu/macos/windows all passed
- `repos/arashi-docs`: `bun run validate`; PR checks/deploy preview passed
- `repos/arashi-skills`: inspected affected skill reference; security gate passed

## Notes
- `bun run typecheck` in `repos/arashi` currently reports pre-existing/unrelated project errors; the dry-run implementation path was validated with the repository's test/build/CI gates above.
