### PR TITLE
docs: propose arashi doctor command

### DIFF
--- a/openspec/changes/add-arashi-doctor/.openspec.yaml
+++ b/openspec/changes/add-arashi-doctor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/add-arashi-doctor/design.md
+++ b/openspec/changes/add-arashi-doctor/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Arashi already exposes most of the raw signals needed for workspace diagnosis, but they live behind separate command flows:
+
+- `status` checks repository presence, dirty state, branch tracking, and default-branch drift.
+- `prune --dry-run` discovers Git-prunable worktree metadata.
+- `clone`, `setup`, `shell`, `install`, and `update` each contain targeted recovery or environment checks.
+- Hook validation exists in command-specific paths such as remove/create hook previews rather than a single health surface.
+
+`doctor` should compose these signals into a single read-only diagnostic command. It should be safer than asking users or agents to run mutating recovery commands just to understand the workspace state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a non-mutating CLI command that can be run early in troubleshooting.
+- Produce stable finding codes and severities that tests, docs, agents, and future UI surfaces can reference.
+- Reuse existing config, status, pruning, shell, hook, and install/update helper code where practical instead of adding separate Git/config parsers.
+- Keep JSON mode aligned with Arashi's existing envelope and stdout-isolation contract.
+- Document practical fix commands alongside findings.
+
+**Non-Goals:**
+
+- Automatically repair workspace state; suggested commands are informational unless a future explicit `--fix` proposal is accepted.
+- Replace detailed command output from `status`, `prune`, `shell`, `setup`, or `update`.
+- Contact remote services more broadly than existing status/update-style checks already do; implementation should keep remote checks bounded and resilient.
+- Guarantee shell integration detection in every shell/terminal; unknown status should be informational rather than a failure.
+
+## Decisions
+
+### Model diagnostics as findings
+
+Represent every diagnostic as a finding with a stable `code`, `severity`, `category`, `scope`, `message`, optional `details`, and zero or more `suggestedCommands`.
+
+Rationale: findings let human output group by severity/category while JSON consumers can make decisions without scraping prose. Stable codes also make tests less brittle than matching full text.
+
+Alternative considered: print a command-specific checklist only. That is simpler for humans, but not sufficient for agents and future integrations.
+
+### Treat blocking findings as the exit-code boundary
+
+Use severities such as `error`, `warning`, and `info`. The command exits non-zero when at least one `error` finding exists or a required diagnostic phase cannot run. Warnings and informational hints should not make the command fail.
+
+Rationale: this matches the issue's requirement for non-zero blocking health failures while allowing useful warnings such as dirty worktrees or missing shell integration hints without making every advisory state fail.
+
+Alternative considered: fail on any non-clean finding. That would make the command noisy for common non-blocking states such as local changes.
+
+### Compose existing checkers behind a doctor runner
+
+Add a `commands/doctor.ts` command backed by a reusable diagnostic runner (for example `lib/doctor.ts` or `core/doctor.ts`). The runner should call existing helpers where possible:
+
+- Workspace/config discovery from `findWorkspaceRoot`, `loadConfig`, and config validation errors.
+- Repository health from the status command's parsing/status helpers, refactored/exported only as needed.
+- Stale worktree metadata from prune/remove discovery helpers.
+- Hook file validation from hook-resolution utilities or a shared validation helper.
+- Shell integration and install/update hints from existing shell/update detection helpers where those checks are safely detectable.
+
+Rationale: doctor must agree with the commands it recommends. Shared helpers reduce drift between `doctor`, `status`, and `prune`.
+
+Alternative considered: implement all checks independently inside the command. That is faster initially but risks inconsistent behavior and duplicated Git edge cases.
+
+### Keep the first implementation conservative
+
+The first pass should cover the acceptance-criteria checks plus safe advisory hints. Ambiguous environment checks, such as shell integration or install channel, should return `info`/`warning` findings only when detectable and should avoid destructive probes.
+
+Rationale: a diagnostic command should be safe to run in CI, local terminals, and agent contexts. Conservative checks leave room for future capabilities without overpromising.
+
+Alternative considered: deeply inspect all install channels and shell startup files up front. That could be useful but increases platform-specific complexity and false positives.
+
+### Document command references and agent troubleshooting paths
+
+Add a docs command page for `doctor`, include it in command navigation, and mention it from agent/troubleshooting-oriented workflow pages. Update Arashi skill guidance so agents run `arashi doctor --json` for structured diagnostics when diagnosing workspace health.
+
+Rationale: `doctor` is most useful when users and agents know it is the safe first command before mutating recovery flows.
+
+## Risks / Trade-offs
+
+- [Risk] Reusing status helpers may require refactoring currently local functions from `commands/status.ts`. → Mitigation: extract shared parsing/checking code in small commits and keep status output behavior covered by existing tests.
+- [Risk] Diagnostic severities can become subjective. → Mitigation: define explicit severity rules in the spec and assert representative states in tests.
+- [Risk] Shell/install detection can produce false positives on uncommon environments. → Mitigation: keep unknown states informational and make suggested commands conservative.
+- [Risk] JSON consumers may depend on finding details too early. → Mitigation: guarantee stable top-level fields and codes; keep detailed payloads additive.
+- [Risk] Doctor could become a dumping ground for every command's edge cases. → Mitigation: scope first implementation to workspace health, repository state, stale metadata, hooks, shell integration hints, and install/update hints from the issue.

--- a/openspec/changes/add-arashi-doctor/proposal.md
+++ b/openspec/changes/add-arashi-doctor/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Workspace health problems are currently diagnosed through a mix of `status`, `clone`, `prune`, `shell`, `setup`, docs troubleshooting, and ad hoc Git inspection. A dedicated non-mutating `arashi doctor` command would give humans and agents one safe entry point for understanding what is wrong and which Arashi command to run next.
+
+## What Changes
+
+- Add an `arashi doctor` CLI command that inspects the current Arashi workspace without mutating repository, worktree, hook, shell, or install state.
+- Report diagnostic findings with stable codes, severity, affected repository or workspace scope, explanatory messages, and suggested fix commands where practical.
+- Group human output by severity or category so blocking issues, warnings, and informational hints are easy to scan.
+- Support `arashi doctor --json` using the existing single-envelope stdout contract for automation and agents.
+- Define exit behavior: success when there are no blocking health failures; non-zero when one or more blocking findings are present or the command cannot complete required checks.
+- Document the command and update agent/skill guidance so troubleshooting flows can prefer `doctor` before lower-level commands.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-health-diagnostics`: Defines non-mutating Arashi workspace health diagnostics, finding shape, severity handling, exit codes, and JSON/human output expectations for `arashi doctor`.
+
+### Modified Capabilities
+
+- `machine-readable-cli-output`: Add `doctor --json` to the set of automation-relevant commands that must obey the structured JSON envelope and stdout-isolation contract.
+
+## Impact
+
+- `repos/arashi`: CLI command registration, workspace/config/status/worktree/hook/shell/install diagnostic helpers, JSON envelope output, and integration/unit tests.
+- `repos/arashi-docs`: Command documentation and troubleshooting/agent workflow references for `arashi doctor`.
+- `repos/arashi-skills`: Agent guidance updates so future agents can use `arashi doctor` for safe diagnostics.
+- No breaking changes; the command is additive and non-mutating by default.

--- a/openspec/changes/add-arashi-doctor/specs/machine-readable-cli-output/spec.md
+++ b/openspec/changes/add-arashi-doctor/specs/machine-readable-cli-output/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Command support audit
+
+The Arashi CLI SHALL audit every user-facing command and explicitly classify JSON behavior as supported, unsupported for a specific mode, or not applicable.
+
+#### Scenario: Automation-relevant command has structured results
+- **WHEN** a user runs an automation-relevant command such as `clone`, `create`, `doctor`, `init`, `install`, `prune`, `pull`, `setup`, `status`, `sync`, or `update` with `--json`
+- **THEN** the command either returns a structured JSON success/failure envelope or documents and emits a structured unsupported-mode error for the requested mode
+
+#### Scenario: Existing JSON command is audited
+- **WHEN** a user runs an existing JSON-capable command such as `list`, `add`, or `remove` with `--json`
+- **THEN** the command participates in the same envelope and stdout-isolation contract as newly supported commands

--- a/openspec/changes/add-arashi-doctor/specs/workspace-health-diagnostics/spec.md
+++ b/openspec/changes/add-arashi-doctor/specs/workspace-health-diagnostics/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: Doctor command performs non-mutating workspace diagnostics
+
+The system SHALL provide `arashi doctor` as a non-mutating health check for the current Arashi workspace.
+
+#### Scenario: Doctor runs in a healthy workspace
+- **WHEN** the user runs `arashi doctor` in an Arashi workspace with valid configuration, present repositories, no blocking repository failures, no stale worktree metadata, and no blocking hook problems
+- **THEN** the command reports that the workspace has no blocking health findings
+- **AND** the command exits successfully
+- **AND** the command does not modify configuration, repositories, worktrees, hooks, shell startup files, install state, or update state
+
+#### Scenario: Doctor is run outside a workspace
+- **WHEN** the user runs `arashi doctor` outside an Arashi workspace
+- **THEN** the command reports a blocking finding that no Arashi workspace was found
+- **AND** the command suggests initializing or switching to an Arashi workspace where practical
+- **AND** the command exits non-zero
+
+#### Scenario: Doctor checks invalid configuration
+- **WHEN** the user runs `arashi doctor` and `.arashi/config.json` is missing, unreadable, malformed, or fails supported configuration validation
+- **THEN** the command reports a blocking configuration finding with a stable code
+- **AND** the finding identifies the affected configuration path when available
+- **AND** the command exits non-zero
+
+### Requirement: Doctor reports repository health findings
+
+The system SHALL inspect configured repositories and report health findings for missing repositories, dirty worktrees, detached heads, untracked branches, upstream divergence, and default-branch drift.
+
+#### Scenario: Configured child repository is missing
+- **WHEN** the user runs `arashi doctor` in a workspace where a configured child repository path is absent
+- **THEN** the command reports a finding with a stable missing-repository code
+- **AND** the finding identifies the repository name and expected path
+- **AND** the finding suggests `arashi clone` or an equivalent targeted clone command
+
+#### Scenario: Repository has uncommitted changes
+- **WHEN** the user runs `arashi doctor` and a configured repository has staged, unstaged, or untracked changes
+- **THEN** the command reports a repository finding that identifies the dirty repository
+- **AND** the finding summarizes the changed-file categories without requiring full file-by-file output
+- **AND** the finding suggests inspecting `arashi status --verbose` or the repository's Git status
+
+#### Scenario: Repository branch state needs attention
+- **WHEN** the user runs `arashi doctor` and a configured repository is detached, lacks an upstream, is ahead of its upstream, is behind its upstream, has a missing remote ref, or is behind its default branch
+- **THEN** the command reports a repository finding with a stable branch-state code
+- **AND** the finding identifies the affected repository and branch relationship when known
+- **AND** the finding suggests an appropriate follow-up command such as `arashi status`, `arashi pull`, `arashi push`, or a Git branch command where practical
+
+#### Scenario: Repository status check fails
+- **WHEN** the user runs `arashi doctor` and Git status cannot be collected for a configured repository
+- **THEN** the command reports a blocking repository finding with the underlying failure message
+- **AND** the command continues collecting independent diagnostics for other repositories when safe
+- **AND** the final command exits non-zero
+
+### Requirement: Doctor reports stale worktree metadata
+
+The system SHALL inspect Git-prunable worktree metadata across the workspace and report stale metadata without pruning it.
+
+#### Scenario: Stale worktree metadata exists
+- **WHEN** the user runs `arashi doctor` and one or more configured repositories contain Git-prunable worktree records
+- **THEN** the command reports a stale-worktree finding for each affected repository
+- **AND** each finding includes the stale worktree path and Git prune reason when available
+- **AND** the finding suggests `arashi prune --dry-run` for review and `arashi prune` for cleanup
+- **AND** the command does not run a mutating prune operation
+
+#### Scenario: Stale worktree discovery fails
+- **WHEN** the user runs `arashi doctor` and stale worktree discovery fails for a repository
+- **THEN** the command reports a blocking stale-worktree diagnostic finding for that repository
+- **AND** the command exits non-zero after completing independent checks when safe
+
+### Requirement: Doctor validates hook configuration and hook files
+
+The system SHALL report configured lifecycle hook files that are missing, not executable when executability is required, or fail Arashi's supported hook safety validation.
+
+#### Scenario: Configured hook file is missing
+- **WHEN** the user runs `arashi doctor` and a configured hook points to a file that does not exist
+- **THEN** the command reports a hook finding with a stable missing-hook code
+- **AND** the finding identifies the hook name, scope, repository or workspace target, and expected path
+
+#### Scenario: Configured hook file is not executable
+- **WHEN** the user runs `arashi doctor` and a configured hook file exists but cannot be executed by Arashi's hook runner
+- **THEN** the command reports a hook finding with a stable hook-permission code
+- **AND** the finding suggests a command such as `chmod +x <hook-path>` when that recommendation is safe and platform-appropriate
+
+#### Scenario: Hook validation detects unsafe or unsupported configuration
+- **WHEN** the user runs `arashi doctor` and hook validation rejects a hook as unsafe or unsupported
+- **THEN** the command reports a blocking hook finding with the validation reason
+- **AND** the command exits non-zero
+
+### Requirement: Doctor reports shell and install/update hints conservatively
+
+The system SHALL include shell integration and install/update channel diagnostics only when they can be detected safely without modifying user environment state.
+
+#### Scenario: Shell integration appears unavailable
+- **WHEN** the user runs `arashi doctor` in an environment where Arashi can safely determine that parent-shell integration is unavailable or not loaded
+- **THEN** the command reports a non-blocking shell-integration finding
+- **AND** the finding suggests `arashi shell install` or `arashi shell init <shell>` where the shell is known
+
+#### Scenario: Shell integration status is unknown
+- **WHEN** the user runs `arashi doctor` and Arashi cannot safely determine shell integration status
+- **THEN** the command does not report a blocking shell finding
+- **AND** any shell-related message is informational and clearly states that status is unknown
+
+#### Scenario: Install or update channel hint is available
+- **WHEN** the user runs `arashi doctor` and Arashi can safely detect an install or update channel condition relevant to workspace health
+- **THEN** the command reports a non-blocking install/update finding
+- **AND** the finding suggests an appropriate follow-up command such as `arashi update --dry-run`, `arashi update --yes`, or install-channel documentation where practical
+
+### Requirement: Doctor human output is actionable and grouped
+
+The system SHALL format default `arashi doctor` output for humans by grouping findings by severity or diagnostic category and showing actionable next steps.
+
+#### Scenario: Human output contains findings
+- **WHEN** the user runs `arashi doctor` and findings are present
+- **THEN** the output groups findings by severity or category
+- **AND** each finding displays its code, affected scope, message, and suggested commands when available
+- **AND** blocking findings are visually distinguishable from warnings and informational hints
+
+#### Scenario: Human output has no findings
+- **WHEN** the user runs `arashi doctor` and no findings are present
+- **THEN** the output states that no workspace health findings were detected
+- **AND** the command exits successfully
+
+### Requirement: Doctor JSON output is stable for automation
+
+The system SHALL support `arashi doctor --json` with a single structured JSON document that includes stable finding codes and summary counts.
+
+#### Scenario: Doctor JSON succeeds with no blocking findings
+- **WHEN** the user runs `arashi doctor --json` and no blocking findings are present
+- **THEN** stdout contains exactly one valid JSON envelope with `ok: true`, `command: "doctor"`, and `schemaVersion: 1`
+- **AND** the data object includes the workspace root, checked categories, findings array, and summary counts by severity
+- **AND** stdout contains no human-readable progress, spinners, colors, tables, banners, or prompts
+
+#### Scenario: Doctor JSON reports blocking findings
+- **WHEN** the user runs `arashi doctor --json` and one or more blocking findings are present
+- **THEN** stdout contains exactly one valid JSON envelope with `ok: false`, `command: "doctor"`, and `schemaVersion: 1`
+- **AND** the error or data details include the findings array and summary counts by severity
+- **AND** the process exits non-zero
+
+#### Scenario: Doctor finding shape is stable
+- **WHEN** the user parses a finding from `arashi doctor --json`
+- **THEN** each finding includes at least `code`, `severity`, `category`, `message`, and `scope`
+- **AND** suggested commands, paths, repository names, and raw diagnostic details are additive structured fields rather than replacements for the stable fields

--- a/openspec/changes/add-arashi-doctor/tasks.md
+++ b/openspec/changes/add-arashi-doctor/tasks.md
@@ -1,45 +1,45 @@
 ## 1. CLI Diagnostic Foundation
 
-- [ ] 1.1 Add `arashi doctor` command registration, help text, and option parsing with `--json` support.
-- [ ] 1.2 Define shared doctor finding types with stable `code`, `severity`, `category`, `scope`, `message`, optional `details`, and `suggestedCommands` fields.
-- [ ] 1.3 Implement a non-mutating doctor runner that discovers the workspace root, loads configuration, collects independent diagnostic phases, and summarizes severity counts.
-- [ ] 1.4 Implement human output grouped by severity or category with clear blocking/warning/info labels and suggested commands.
-- [ ] 1.5 Implement JSON success and failure envelopes for `doctor --json` with stdout isolation and non-zero exit for blocking findings.
+- [x] 1.1 Add `arashi doctor` command registration, help text, and option parsing with `--json` support.
+- [x] 1.2 Define shared doctor finding types with stable `code`, `severity`, `category`, `scope`, `message`, optional `details`, and `suggestedCommands` fields.
+- [x] 1.3 Implement a non-mutating doctor runner that discovers the workspace root, loads configuration, collects independent diagnostic phases, and summarizes severity counts.
+- [x] 1.4 Implement human output grouped by severity or category with clear blocking/warning/info labels and suggested commands.
+- [x] 1.5 Implement JSON success and failure envelopes for `doctor --json` with stdout isolation and non-zero exit for blocking findings.
 
 ## 2. Workspace and Repository Checks
 
-- [ ] 2.1 Report missing, malformed, unreadable, or invalid `.arashi/config.json` as blocking configuration findings.
-- [ ] 2.2 Reuse or extract status helpers to collect configured repository presence, Git status, branch tracking, detached-head, upstream divergence, missing remote-ref, and default-branch drift diagnostics.
-- [ ] 2.3 Report missing child repositories with clone-oriented suggested commands.
-- [ ] 2.4 Report dirty repositories with summarized staged/unstaged/untracked counts and status-inspection suggestions.
-- [ ] 2.5 Ensure repository status failures become blocking findings while independent repositories/checks still run when safe.
+- [x] 2.1 Report missing, malformed, unreadable, or invalid `.arashi/config.json` as blocking configuration findings.
+- [x] 2.2 Reuse or extract status helpers to collect configured repository presence, Git status, branch tracking, detached-head, upstream divergence, missing remote-ref, and default-branch drift diagnostics.
+- [x] 2.3 Report missing child repositories with clone-oriented suggested commands.
+- [x] 2.4 Report dirty repositories with summarized staged/unstaged/untracked counts and status-inspection suggestions.
+- [x] 2.5 Ensure repository status failures become blocking findings while independent repositories/checks still run when safe.
 
 ## 3. Worktree, Hook, Shell, and Install Checks
 
-- [ ] 3.1 Reuse stale worktree discovery from prune/remove helpers and report prunable metadata without running `git worktree prune`.
-- [ ] 3.2 Add hook validation diagnostics for missing hook files, non-executable hook files, and unsafe or unsupported hook definitions.
-- [ ] 3.3 Add conservative shell-integration hints that never fail the command when integration status is unknown.
-- [ ] 3.4 Add conservative install/update channel hints only when they can be detected safely without modifying environment state.
+- [x] 3.1 Reuse stale worktree discovery from prune/remove helpers and report prunable metadata without running `git worktree prune`.
+- [x] 3.2 Add hook validation diagnostics for missing hook files, non-executable hook files, and unsafe or unsupported hook definitions.
+- [x] 3.3 Add conservative shell-integration hints that never fail the command when integration status is unknown.
+- [x] 3.4 Add conservative install/update channel hints only when they can be detected safely without modifying environment state.
 
 ## 4. Tests
 
-- [ ] 4.1 Add healthy-workspace tests for human and JSON `doctor` output.
-- [ ] 4.2 Add invalid-config and outside-workspace tests covering blocking findings and exit codes.
-- [ ] 4.3 Add missing-repository, dirty-repository, detached/untracked/diverged branch, and default-branch drift tests.
-- [ ] 4.4 Add stale worktree metadata tests proving doctor reports prunable records without pruning them.
-- [ ] 4.5 Add hook diagnostics tests for missing, non-executable, and invalid hook configurations.
-- [ ] 4.6 Add stdout-isolation tests proving `doctor --json` emits exactly one JSON document with no human progress text.
+- [x] 4.1 Add healthy-workspace tests for human and JSON `doctor` output.
+- [x] 4.2 Add invalid-config and outside-workspace tests covering blocking findings and exit codes.
+- [x] 4.3 Add missing-repository, dirty-repository, detached/untracked/diverged branch, and default-branch drift tests.
+- [x] 4.4 Add stale worktree metadata tests proving doctor reports prunable records without pruning them.
+- [x] 4.5 Add hook diagnostics tests for missing, non-executable, and invalid hook configurations.
+- [x] 4.6 Add stdout-isolation tests proving `doctor --json` emits exactly one JSON document with no human progress text.
 
 ## 5. Documentation and Agent Guidance
 
-- [ ] 5.1 Add an `arashi doctor` command page to `repos/arashi-docs` and include options, examples, exit behavior, finding severities, and JSON shape.
-- [ ] 5.2 Update troubleshooting or agent workflow docs to recommend `arashi doctor` as the safe first diagnostic command.
-- [ ] 5.3 Update `repos/arashi-skills` guidance to prefer `arashi doctor --json` when agents need structured workspace health diagnostics.
-- [ ] 5.4 Update generated agent-readable docs/exports if the docs build requires committed generated route changes.
+- [x] 5.1 Add an `arashi doctor` command page to `repos/arashi-docs` and include options, examples, exit behavior, finding severities, and JSON shape.
+- [x] 5.2 Update troubleshooting or agent workflow docs to recommend `arashi doctor` as the safe first diagnostic command.
+- [x] 5.3 Update `repos/arashi-skills` guidance to prefer `arashi doctor --json` when agents need structured workspace health diagnostics.
+- [x] 5.4 Update generated agent-readable docs/exports if the docs build requires committed generated route changes.
 
 ## 6. Validation and PR Choreography
 
-- [ ] 6.1 Validate `repos/arashi` with `bun run lint`, `bun run test`, and `bun run build`.
-- [ ] 6.2 Validate `repos/arashi-docs` with `bun run validate` and smoke-check the generated command/agent-readable routes for doctor content.
-- [ ] 6.3 Validate `repos/arashi-skills` with its repository checks or a focused content smoke check.
-- [ ] 6.4 Open cross-linked implementation PRs for affected child repositories and update the meta/OpenSpec PR body with final related PR links before merge.
+- [x] 6.1 Validate `repos/arashi` with `bun run lint`, `bun run test`, and `bun run build`.
+- [x] 6.2 Validate `repos/arashi-docs` with `bun run validate` and smoke-check the generated command/agent-readable routes for doctor content.
+- [x] 6.3 Validate `repos/arashi-skills` with its repository checks or a focused content smoke check.
+- [x] 6.4 Open cross-linked implementation PRs for affected child repositories and update the meta/OpenSpec PR body with final related PR links before merge.

--- a/openspec/changes/add-arashi-doctor/tasks.md
+++ b/openspec/changes/add-arashi-doctor/tasks.md
@@ -1,0 +1,45 @@
+## 1. CLI Diagnostic Foundation
+
+- [ ] 1.1 Add `arashi doctor` command registration, help text, and option parsing with `--json` support.
+- [ ] 1.2 Define shared doctor finding types with stable `code`, `severity`, `category`, `scope`, `message`, optional `details`, and `suggestedCommands` fields.
+- [ ] 1.3 Implement a non-mutating doctor runner that discovers the workspace root, loads configuration, collects independent diagnostic phases, and summarizes severity counts.
+- [ ] 1.4 Implement human output grouped by severity or category with clear blocking/warning/info labels and suggested commands.
+- [ ] 1.5 Implement JSON success and failure envelopes for `doctor --json` with stdout isolation and non-zero exit for blocking findings.
+
+## 2. Workspace and Repository Checks
+
+- [ ] 2.1 Report missing, malformed, unreadable, or invalid `.arashi/config.json` as blocking configuration findings.
+- [ ] 2.2 Reuse or extract status helpers to collect configured repository presence, Git status, branch tracking, detached-head, upstream divergence, missing remote-ref, and default-branch drift diagnostics.
+- [ ] 2.3 Report missing child repositories with clone-oriented suggested commands.
+- [ ] 2.4 Report dirty repositories with summarized staged/unstaged/untracked counts and status-inspection suggestions.
+- [ ] 2.5 Ensure repository status failures become blocking findings while independent repositories/checks still run when safe.
+
+## 3. Worktree, Hook, Shell, and Install Checks
+
+- [ ] 3.1 Reuse stale worktree discovery from prune/remove helpers and report prunable metadata without running `git worktree prune`.
+- [ ] 3.2 Add hook validation diagnostics for missing hook files, non-executable hook files, and unsafe or unsupported hook definitions.
+- [ ] 3.3 Add conservative shell-integration hints that never fail the command when integration status is unknown.
+- [ ] 3.4 Add conservative install/update channel hints only when they can be detected safely without modifying environment state.
+
+## 4. Tests
+
+- [ ] 4.1 Add healthy-workspace tests for human and JSON `doctor` output.
+- [ ] 4.2 Add invalid-config and outside-workspace tests covering blocking findings and exit codes.
+- [ ] 4.3 Add missing-repository, dirty-repository, detached/untracked/diverged branch, and default-branch drift tests.
+- [ ] 4.4 Add stale worktree metadata tests proving doctor reports prunable records without pruning them.
+- [ ] 4.5 Add hook diagnostics tests for missing, non-executable, and invalid hook configurations.
+- [ ] 4.6 Add stdout-isolation tests proving `doctor --json` emits exactly one JSON document with no human progress text.
+
+## 5. Documentation and Agent Guidance
+
+- [ ] 5.1 Add an `arashi doctor` command page to `repos/arashi-docs` and include options, examples, exit behavior, finding severities, and JSON shape.
+- [ ] 5.2 Update troubleshooting or agent workflow docs to recommend `arashi doctor` as the safe first diagnostic command.
+- [ ] 5.3 Update `repos/arashi-skills` guidance to prefer `arashi doctor --json` when agents need structured workspace health diagnostics.
+- [ ] 5.4 Update generated agent-readable docs/exports if the docs build requires committed generated route changes.
+
+## 6. Validation and PR Choreography
+
+- [ ] 6.1 Validate `repos/arashi` with `bun run lint`, `bun run test`, and `bun run build`.
+- [ ] 6.2 Validate `repos/arashi-docs` with `bun run validate` and smoke-check the generated command/agent-readable routes for doctor content.
+- [ ] 6.3 Validate `repos/arashi-skills` with its repository checks or a focused content smoke check.
+- [ ] 6.4 Open cross-linked implementation PRs for affected child repositories and update the meta/OpenSpec PR body with final related PR links before merge.


### PR DESCRIPTION
## Summary
- Proposes and applies the `arashi doctor` workspace health diagnostic command.
- Defines a non-mutating diagnostic model with stable findings, severities, grouped human output, and JSON support.
- Tracks the CLI, docs, and skills implementation PRs for the approved spec.

## Related / implementation PRs
- Closes #178.
- CLI implementation: corwinm/arashi#81.
- Documentation: corwinm/arashi-docs#38.
- Agent guidance: corwinm/arashi-skills#32.

## Validation
- `openspec validate add-arashi-doctor`
- `repos/arashi`: `bun run lint`, `bun run test` (778 pass), `bun run build`
- `repos/arashi-docs`: `bun run validate`; smoke checked `public/commands/doctor.md` and `public/llms-full.txt`
- `repos/arashi-skills`: `node scripts/security-gate.mjs --root . --exceptions security/audit-exceptions.json`; `node scripts/security-gate-selftest.mjs`
- Smoke: `bun src/index.ts doctor --json`
