### PR TITLE
docs: normalize legacy OpenSpec specs

### DIFF
--- a/openspec/specs/cli-readme-value-example/spec.md
+++ b/openspec/specs/cli-readme-value-example/spec.md
@@ -1,5 +1,9 @@
-## MODIFIED Requirements
+# cli-readme-value-example Specification
 
+## Purpose
+Define README requirements that explain Arashi's current OpenSpec-based multi-repo value proposition and keep historical SpecKit references clearly contextualized.
+
+## Requirements
 ### Requirement: CLI README SHALL include a value-focused multi-repo example section
 The CLI README SHALL include a dedicated section that explains Arashi's value through a minimal frontend-and-backend multi-repo workflow and SHALL identify OpenSpec as the current spec workflow used for this project.
 

--- a/openspec/specs/docs-landing-value-proposition/spec.md
+++ b/openspec/specs/docs-landing-value-proposition/spec.md
@@ -1,5 +1,9 @@
-## ADDED Requirements
+# docs-landing-value-proposition Specification
 
+## Purpose
+Define landing-page requirements that communicate Arashi's multi-repo parallel-worktree value proposition through concise, action-oriented onboarding copy.
+
+## Requirements
 ### Requirement: Landing page SHALL communicate Arashi's multi-repo value above the fold
 The docs landing page SHALL present a primary value proposition that explains users can coordinate multiple repositories and multiple worktrees in parallel without losing context.
 

--- a/openspec/specs/docs-workflow-guidance-sections/spec.md
+++ b/openspec/specs/docs-workflow-guidance-sections/spec.md
@@ -1,5 +1,9 @@
-## ADDED Requirements
+# docs-workflow-guidance-sections Specification
 
+## Purpose
+Define documentation requirements for discoverable workflow guidance covering hooks, configuration, integrations, and onboarding cross-links.
+
+## Requirements
 ### Requirement: Docs SHALL provide dedicated workflow guidance for hooks, configuration, and integrations
 The documentation SHALL provide dedicated, discoverable guidance for hooks, configuration options, and integrations instead of requiring users to infer those workflows only from command-reference pages.
 

--- a/openspec/specs/meta-repo-readme-openspec-guidance/spec.md
+++ b/openspec/specs/meta-repo-readme-openspec-guidance/spec.md
@@ -1,5 +1,9 @@
-## ADDED Requirements
+# meta-repo-readme-openspec-guidance Specification
 
+## Purpose
+Define root README requirements that identify OpenSpec as the current Arashi planning workflow while treating SpecKit as historical context only.
+
+## Requirements
 ### Requirement: Meta-repo README SHALL identify OpenSpec as the current workflow
 The root `arashi-arashi` `README.md` SHALL identify OpenSpec as the current workflow used for specification and change planning in this repository.
 

--- a/openspec/specs/multi-repo-worktree-visual-walkthrough/spec.md
+++ b/openspec/specs/multi-repo-worktree-visual-walkthrough/spec.md
@@ -1,5 +1,9 @@
-## ADDED Requirements
+# multi-repo-worktree-visual-walkthrough Specification
 
+## Purpose
+Define documentation requirements for an accurate visual walkthrough of Arashi's minimal multi-repo add, create, and switch workflow.
+
+## Requirements
 ### Requirement: Docs SHALL provide a visual walkthrough of the minimal multi-repo workflow
 The docs landing page SHALL provide visuals that depict adding repositories, creating worktrees, and switching between worktrees while another worktree remains active.
 


### PR DESCRIPTION
## Summary
- Normalizes the five remaining legacy OpenSpec durable spec files from delta-style headings into the current synced-spec format.
- Adds concise `## Purpose` sections to each affected spec.
- Preserves the existing requirement/scenario content under `## Requirements`.

## Affected specs
- `openspec/specs/cli-readme-value-example/spec.md`
- `openspec/specs/docs-landing-value-proposition/spec.md`
- `openspec/specs/docs-workflow-guidance-sections/spec.md`
- `openspec/specs/meta-repo-readme-openspec-guidance/spec.md`
- `openspec/specs/multi-repo-worktree-visual-walkthrough/spec.md`

## Validation
- `openspec validate --all` → 37 passed, 0 failed
