### PR TITLE
fix: decouple command contract from release version

### DIFF
--- a/openspec/changes/remove-cli-version-contract-coupling/.openspec.yaml
+++ b/openspec/changes/remove-cli-version-contract-coupling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/remove-cli-version-contract-coupling/design.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The CLI contract generator builds a deterministic JSON artifact from the same Commander program used at runtime. Its `cliVersion` field is copied from `package.json`, while its `schemaVersion` field already versions the contract format. Semantic-release updates `package.json` in a `[skip ci]` release commit, which changes generated output even when no command metadata changed and leaves the checked-in contract stale.
+
+The meta-repository validator also requires `cliVersion`, so removing the coupling requires coordinated CLI and meta changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make command-contract freshness depend only on contract structure and semantic policy.
+- Preserve deterministic generation and schema compatibility validation.
+- Keep runtime `arashi --version` behavior sourced from `package.json`.
+- Update the canonical consumer and tests together.
+
+**Non-Goals:**
+
+- Change semantic-release, package publication, tags, or changelog behavior.
+- Change commands, options, companion-surface policies, or runtime output.
+- Introduce another release-version manifest.
+
+## Decisions
+
+### Treat `schemaVersion` as the contract's only version field
+
+Remove `cliVersion` from `CliCommandContract` and generated JSON. A contract checked out at a release tag is already associated with that release, while `schemaVersion` is the compatibility signal consumers actually need.
+
+Alternative: teach semantic-release to regenerate and commit the contract on every release. Rejected because it creates meaningless contract churn, depends on plugin ordering, and preserves coupling between interface validation and release bookkeeping.
+
+Alternative: retain `cliVersion` but ignore it during freshness checks. Rejected because checked-in generated output would still be stale and consumers could mistake the field for a compatibility guarantee.
+
+### Keep runtime version handling unchanged
+
+`buildProgram()` continues to call Commander `.version(pkg.version)`, so `arashi --version` and update behavior remain tied to the package release. Only serialization of the command-surface contract changes.
+
+### Coordinate consumer validation in the meta-repository
+
+The meta checker will require a supported `schemaVersion` and `commands` array, and fixtures will no longer carry arbitrary CLI package versions. This makes the consumer validate the contract format rather than release provenance.
+
+## Risks / Trade-offs
+
+- **[Risk] An unknown consumer relies on `cliVersion`** → Repository-wide inspection found only the CLI generator and meta validator; the coordinated PRs update both known producers and consumers.
+- **[Risk] Removing a JSON field is treated as a schema change** → Increment `schemaVersion` from 1 to 2 and make the meta validator require version 2, explicitly representing the shape change.
+- **[Risk] Companion repositories temporarily consume mismatched revisions** → Land the green CLI child PR first, then update and merge the meta/OpenSpec PR as the coordination point.
+
+## Migration Plan
+
+1. Add failing CLI and meta tests for a schema-versioned contract without `cliVersion`.
+2. Remove the field, bump the contract schema to 2, and regenerate the artifact.
+3. Update meta validation and fixtures to require schema version 2.
+4. Run repository-local and coordinated contract checks.
+5. Merge the child CLI PR before the meta/OpenSpec PR.
+
+Rollback by reverting both coordinated PRs; runtime CLI version behavior is unaffected either way.
+
+## Open Questions
+
+None.

--- a/openspec/changes/remove-cli-version-contract-coupling/proposal.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The checked-in CLI command contract currently embeds the package release version, so semantic-release makes the contract stale even when the command surface is unchanged. This couples interface-drift validation to release bookkeeping and allowed a skipped release commit to leave `main` failing its next unrelated pull request.
+
+## What Changes
+
+- Remove the package release version from the generated CLI command contract.
+- Keep `schemaVersion` as the contract format version and continue deriving command structure and semantics from the runtime Commander tree.
+- Update meta-repository contract parsing and fixtures so cross-repository validation requires the contract schema version and command list rather than a duplicated CLI release version.
+- Regenerate the canonical contract and verify ordinary package-version changes no longer affect contract freshness.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cross-repo-command-contracts`: Clarify that contract versioning refers to the contract schema, not the Arashi package release, and require release-version-independent freshness checks.
+
+## Impact
+
+- `corwinm/arashi`: contract type, generator, generated JSON artifact, and focused tests.
+- `corwinm/arashi-arashi`: contract parser validation, fixtures/tests, OpenSpec delta, and cross-repository checks.
+- No runtime CLI behavior, npm package versioning, documentation command coverage, skills guidance, or VS Code mappings change.

--- a/openspec/changes/remove-cli-version-contract-coupling/specs/cross-repo-command-contracts/spec.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/specs/cross-repo-command-contracts/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned deterministic contract artifact
+The CLI repository SHALL generate a deterministic machine-readable command contract whose schema version identifies the contract format, SHALL exclude the package release version from contract freshness, and SHALL provide a freshness check that fails when the checked-in artifact differs from current registration or semantic metadata.
+
+#### Scenario: Contract is current
+- **WHEN** the freshness check runs without command, policy, or contract-schema drift
+- **THEN** it exits successfully without modifying the working tree
+
+#### Scenario: Package release version changes
+- **WHEN** the package release version changes without command, policy, or contract-schema drift
+- **THEN** the generated command contract remains unchanged
+
+#### Scenario: Contract is stale
+- **WHEN** registration, options, semantic metadata, or the contract schema changed without regenerating the artifact
+- **THEN** the freshness check reports the generated difference and exits unsuccessfully

--- a/openspec/changes/remove-cli-version-contract-coupling/specs/cross-repo-command-contracts/spec.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/specs/cross-repo-command-contracts/spec.md
@@ -1,16 +1,20 @@
 ## MODIFIED Requirements
 
 ### Requirement: Versioned deterministic contract artifact
+
 The CLI repository SHALL generate a deterministic machine-readable command contract whose schema version identifies the contract format, SHALL exclude the package release version from contract freshness, and SHALL provide a freshness check that fails when the checked-in artifact differs from current registration or semantic metadata.
 
 #### Scenario: Contract is current
+
 - **WHEN** the freshness check runs without command, policy, or contract-schema drift
 - **THEN** it exits successfully without modifying the working tree
 
 #### Scenario: Package release version changes
+
 - **WHEN** the package release version changes without command, policy, or contract-schema drift
 - **THEN** the generated command contract remains unchanged
 
 #### Scenario: Contract is stale
+
 - **WHEN** registration, options, semantic metadata, or the contract schema changed without regenerating the artifact
 - **THEN** the freshness check reports the generated difference and exits unsuccessfully

--- a/openspec/changes/remove-cli-version-contract-coupling/tasks.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/tasks.md
@@ -1,0 +1,18 @@
+## 1. CLI Contract
+
+- [ ] 1.1 Add failing CLI tests that require schema version 2 and release-version-independent serialization
+- [ ] 1.2 Remove `cliVersion`, bump the contract schema, and regenerate the canonical artifact
+- [ ] 1.3 Run focused contract tests and contract freshness validation
+
+## 2. Meta-Repository Consumer
+
+- [ ] 2.1 Add failing meta-repository tests for schema version 2 contracts without `cliVersion`
+- [ ] 2.2 Update contract parsing, diagnostics, and fixtures to validate schema version and commands
+- [ ] 2.3 Run focused meta tests and the coordinated cross-repository contract check
+
+## 3. Verification and Delivery
+
+- [ ] 3.1 Run CLI format, lint, typecheck, full tests, build, and contract freshness gates
+- [ ] 3.2 Run meta-repository format, typecheck, full tests, OpenSpec validation, and cross-repository checks
+- [ ] 3.3 Independently review both repository diffs and address any blocking findings
+- [ ] 3.4 Commit and open cross-linked CLI and meta/OpenSpec pull requests, then verify remote CI

--- a/openspec/changes/remove-cli-version-contract-coupling/tasks.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/tasks.md
@@ -15,4 +15,4 @@
 - [x] 3.1 Run CLI format, lint, typecheck, full tests, build, and contract freshness gates
 - [x] 3.2 Run meta-repository format, typecheck, full tests, OpenSpec validation, and cross-repository checks
 - [x] 3.3 Independently review both repository diffs and address any blocking findings
-- [ ] 3.4 Commit and open cross-linked CLI and meta/OpenSpec pull requests, then verify remote CI
+- [x] 3.4 Commit and open cross-linked CLI and meta/OpenSpec pull requests, then verify remote CI

--- a/openspec/changes/remove-cli-version-contract-coupling/tasks.md
+++ b/openspec/changes/remove-cli-version-contract-coupling/tasks.md
@@ -1,18 +1,18 @@
 ## 1. CLI Contract
 
-- [ ] 1.1 Add failing CLI tests that require schema version 2 and release-version-independent serialization
-- [ ] 1.2 Remove `cliVersion`, bump the contract schema, and regenerate the canonical artifact
-- [ ] 1.3 Run focused contract tests and contract freshness validation
+- [x] 1.1 Add failing CLI tests that require schema version 2 and release-version-independent serialization
+- [x] 1.2 Remove `cliVersion`, bump the contract schema, and regenerate the canonical artifact
+- [x] 1.3 Run focused contract tests and contract freshness validation
 
 ## 2. Meta-Repository Consumer
 
-- [ ] 2.1 Add failing meta-repository tests for schema version 2 contracts without `cliVersion`
-- [ ] 2.2 Update contract parsing, diagnostics, and fixtures to validate schema version and commands
-- [ ] 2.3 Run focused meta tests and the coordinated cross-repository contract check
+- [x] 2.1 Add failing meta-repository tests for schema version 2 contracts without `cliVersion`
+- [x] 2.2 Update contract parsing, diagnostics, and fixtures to validate schema version and commands
+- [x] 2.3 Run focused meta tests and the coordinated cross-repository contract check
 
 ## 3. Verification and Delivery
 
-- [ ] 3.1 Run CLI format, lint, typecheck, full tests, build, and contract freshness gates
-- [ ] 3.2 Run meta-repository format, typecheck, full tests, OpenSpec validation, and cross-repository checks
-- [ ] 3.3 Independently review both repository diffs and address any blocking findings
+- [x] 3.1 Run CLI format, lint, typecheck, full tests, build, and contract freshness gates
+- [x] 3.2 Run meta-repository format, typecheck, full tests, OpenSpec validation, and cross-repository checks
+- [x] 3.3 Independently review both repository diffs and address any blocking findings
 - [ ] 3.4 Commit and open cross-linked CLI and meta/OpenSpec pull requests, then verify remote CI

--- a/scripts/command-contracts.ts
+++ b/scripts/command-contracts.ts
@@ -104,15 +104,16 @@ function version(
   value: Obj | undefined,
   source: string,
   diagnostics: Diagnostic[],
+  expected = 1,
 ) {
-  if (value && value.schemaVersion !== 1)
+  if (value && value.schemaVersion !== expected)
     diagnostics.push({
       severity: "error",
       category: "schema",
       code: "SCHEMA_VERSION_UNSUPPORTED",
       source,
       subject: String(value.schemaVersion),
-      message: "Expected schemaVersion 1.",
+      message: `Expected schemaVersion ${expected}.`,
     });
 }
 function reason(
@@ -168,16 +169,23 @@ export async function checkContracts(
   const coverage = await json(root, paths.coverage, d);
   const policy = await json(root, paths.policy, d);
   const manifest = await json(root, paths.manifest, d);
-  version(contract, paths.contract, d);
+  version(contract, paths.contract, d, 2);
   version(coverage, paths.coverage, d);
   version(policy, paths.policy, d);
   const commandEntries = Array.isArray(contract?.commands)
     ? contract.commands.filter(object)
     : [];
-  if (
-    contract &&
-    (!text(contract.cliVersion) || !Array.isArray(contract.commands))
-  )
+  if (contract && "cliVersion" in contract)
+    add(
+      d,
+      "error",
+      "schema",
+      "SCHEMA_INVALID",
+      paths.contract,
+      "cliVersion",
+      "Contract schema version 2 excludes package release metadata.",
+    );
+  if (contract && !Array.isArray(contract.commands))
     add(
       d,
       "error",
@@ -185,7 +193,7 @@ export async function checkContracts(
       "SCHEMA_INVALID",
       paths.contract,
       "contract",
-      "Contract requires cliVersion and commands.",
+      "Contract requires commands.",
     );
   const commands = new Map<string, Obj>();
   for (const command of commandEntries) {

--- a/scripts/command-contracts.ts
+++ b/scripts/command-contracts.ts
@@ -175,7 +175,7 @@ export async function checkContracts(
   const commandEntries = Array.isArray(contract?.commands)
     ? contract.commands.filter(object)
     : [];
-  if (contract && "cliVersion" in contract)
+  if (contract?.schemaVersion === 2 && "cliVersion" in contract)
     add(
       d,
       "error",

--- a/tests/command-contracts.test.ts
+++ b/tests/command-contracts.test.ts
@@ -183,18 +183,26 @@ describe("cross-repository command contracts", () => {
       "VSCODE_EXCLUDED",
     ]);
   });
-  test("rejects the previous command contract schema", async () => {
+  test("rejects the previous command contract schema without applying schema 2 rules", async () => {
     const root = await fixture();
     const path = join(root, "repos/arashi/contracts/cli-commands.json");
     const data = JSON.parse(await readFile(path, "utf8"));
     data.schemaVersion = 1;
+    data.cliVersion = "1.20.1";
     await writeFile(path, JSON.stringify(data));
 
-    expect((await checkContracts(root)).diagnostics).toContainEqual(
+    const diagnostics = (await checkContracts(root)).diagnostics;
+    expect(diagnostics).toContainEqual(
       expect.objectContaining({
         code: "SCHEMA_VERSION_UNSUPPORTED",
         source: "repos/arashi/contracts/cli-commands.json",
         subject: "1",
+      }),
+    );
+    expect(diagnostics).not.toContainEqual(
+      expect.objectContaining({
+        code: "SCHEMA_INVALID",
+        subject: "cliVersion",
       }),
     );
   });

--- a/tests/command-contracts.test.ts
+++ b/tests/command-contracts.test.ts
@@ -14,8 +14,7 @@ async function fixture(): Promise<string> {
   roots.push(root);
   const files: Record<string, unknown | string> = {
     "repos/arashi/contracts/cli-commands.json": {
-      schemaVersion: 1,
-      cliVersion: "1.0.0",
+      schemaVersion: 2,
       commands: [
         {
           path: "add",
@@ -183,6 +182,36 @@ describe("cross-repository command contracts", () => {
       "SKILLS_EXCLUDED",
       "VSCODE_EXCLUDED",
     ]);
+  });
+  test("rejects the previous command contract schema", async () => {
+    const root = await fixture();
+    const path = join(root, "repos/arashi/contracts/cli-commands.json");
+    const data = JSON.parse(await readFile(path, "utf8"));
+    data.schemaVersion = 1;
+    await writeFile(path, JSON.stringify(data));
+
+    expect((await checkContracts(root)).diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "SCHEMA_VERSION_UNSUPPORTED",
+        source: "repos/arashi/contracts/cli-commands.json",
+        subject: "1",
+      }),
+    );
+  });
+  test("rejects package release metadata in schema version 2", async () => {
+    const root = await fixture();
+    const path = join(root, "repos/arashi/contracts/cli-commands.json");
+    const data = JSON.parse(await readFile(path, "utf8"));
+    data.cliVersion = "1.20.1";
+    await writeFile(path, JSON.stringify(data));
+
+    expect((await checkContracts(root)).diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "SCHEMA_INVALID",
+        source: "repos/arashi/contracts/cli-commands.json",
+        subject: "cliVersion",
+      }),
+    );
   });
   test("finds missing docs page and index entry", async () => {
     const root = await fixture();


### PR DESCRIPTION
## Summary

- removes package release metadata from the cross-repository CLI command contract
- requires command contract schema version 2 while leaving skills and VS Code policy contracts on schema version 1
- rejects `cliVersion` if it reappears in the schema version 2 artifact
- documents the coordinated migration through OpenSpec

## Why

The contract freshness gate currently fails whenever semantic-release changes `package.json`, even when the command surface is unchanged. The release commit skips CI, so the stale contract is only discovered by the next unrelated PR.

## OpenSpec

- Change: `remove-cli-version-contract-coupling`
- Validation: `openspec validate remove-cli-version-contract-coupling --strict`

## Related implementation

- CLI PR: https://github.com/corwinm/arashi/pull/97

## Validation

- `pnpm run typecheck`
- `pnpm run test` — 16 passed
- `pnpm run contracts:check` — pass with 10 expected informational exclusions
- changed-file Prettier check
- strict OpenSpec validation
- independent review — no blocking findings

## Formatting note

The repository-wide formatting check still identifies four unchanged pre-existing documentation files. This PR does not modify those files; all changed files pass formatting and `git diff --check`.
