### PR TITLE
chore: migrate workspace switch mode config

### DIFF
--- a/.arashi/config.json
+++ b/.arashi/config.json
@@ -9,7 +9,7 @@
       "launchMode": "sesh"
     },
     "switch": {
-      "launchMode": "sesh"
+      "mode": "sesh"
     }
   },
   "repos": {


### PR DESCRIPTION
## Summary

- migrates the tracked workspace configuration from `defaults.switch.launchMode: "sesh"` to `defaults.switch.mode: "sesh"`
- preserves `defaults.create.launch: true` and `defaults.create.launchMode: "sesh"` unchanged
- adopts the canonical switch configuration shipped in Arashi v1.21.0

## Release gate

- CLI implementation: corwinm/arashi#99 (merged)
- coordinating OpenSpec/meta PR: #226 (merged and archived/synced)
- released CLI: [v1.21.0](https://github.com/corwinm/arashi/releases/tag/v1.21.0)
- local CLI used for validation: `1.21.0`
- follow-up create-default simplification remains tracked by #227

## Validation

- `arashi --version` → `1.21.0`
- `arashi doctor --json` → valid JSON, `ok: true`, no migration warning on stderr
- `arashi status --verbose` → no switch-field migration warning
- `arashi list --json` → valid JSON with empty stderr
- released schema from `https://unpkg.com/arashi/schema/config.schema.json` validates `.arashi/config.json`
- config assertions confirm switch mode is `sesh`, both legacy switch fields are absent, and create defaults are unchanged
- `corepack pnpm test` → 18 tests passed
- `corepack pnpm typecheck` → passed
- `corepack pnpm contracts:check` → passed
- `corepack pnpm format:check` → reports four pre-existing formatting findings in unchanged historical docs; this PR does not modify those files

Closes #228
Related to #225
