### PR TITLE
chore: update vulnerable postcss

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,8 +546,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.6.2:
@@ -1024,7 +1024,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -1112,7 +1112,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- updates transitive `postcss` 8.5.19 → 8.5.25 in the cross-repository contract tooling lockfile
- resolves medium-severity Dependabot alert 4 (GHSA-fxqj-rqcc-2cmp / CVE-2026-69153)
- keeps the change lockfile-only with no direct dependency range changes

## Validation
- `pnpm install --frozen-lockfile` resolved the lockfile and installed dependencies; pnpm's build-approval policy initially reported the expected ignored `esbuild` postinstall, which completed when the scripts ran
- `pnpm audit --json` — 0 vulnerabilities
- `pnpm why postcss --depth 10`
- `pnpm run typecheck`
- `pnpm run test` — 81 passed
- `pnpm run contracts:check`
- `pnpm run format:check` reproduces the same four pre-existing Markdown formatting warnings on unchanged `origin/main`

## Related PRs
- https://github.com/corwinm/arashi/pull/114
- https://github.com/corwinm/arashi-docs/pull/62
- https://github.com/corwinm/arashi-vscode/pull/29
