### PR TITLE
Fix pnpm scope in arashi post-create hook

### DIFF
--- a/.arashi/hooks/post-create.arashi.sh
+++ b/.arashi/hooks/post-create.arashi.sh
@@ -2,7 +2,7 @@
 
 echo "***"
 
-pnpm install --frozen-lockfile
-pnpm run build
+pnpm install --ignore-workspace --frozen-lockfile
+pnpm --ignore-workspace run build
 
 echo "***"


### PR DESCRIPTION
## Summary

- keep the pnpm 11 workspace configuration at the meta-repo root
- make the arashi repo post-create hook ignore the enclosing meta-worktree workspace
- ensure install and build resolve `repos/arashi/package.json` and its lockfile

## Why

Arashi places child worktrees beneath the meta-repository worktree. pnpm walks upward from the hook cwd and otherwise discovers the parent `pnpm-workspace.yaml`, causing commands to target the meta-repo package despite the hook running from the correct directory.

Removing the root workspace file is not viable with pnpm 11 because the root uses `allowBuilds` for esbuild, and pnpm 11 stores that policy in `pnpm-workspace.yaml`.

## Validation

- `bash -n .arashi/hooks/post-create.arashi.sh`
- `cd repos/arashi && CI=true pnpm install --ignore-workspace --frozen-lockfile`
- `cd repos/arashi && pnpm --ignore-workspace run build`