### PR TITLE
fix: preserve pnpm trusted build policy in hooks

### DIFF
--- a/.arashi/hooks/post-create.arashi-docs.sh
+++ b/.arashi/hooks/post-create.arashi-docs.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 printf '%s\n' '***'
-CI=true corepack pnpm --ignore-workspace install --frozen-lockfile
+CI=true corepack pnpm install --frozen-lockfile
 printf '%s\n' '***'

--- a/.arashi/hooks/post-create.arashi-presentation.sh
+++ b/.arashi/hooks/post-create.arashi-presentation.sh
@@ -7,6 +7,6 @@ if [[ -x "$HOME/.vite-plus/bin/node" ]]; then
 fi
 
 printf '%s\n' '***'
-CI=true corepack pnpm --ignore-workspace install --frozen-lockfile --config.strict-dep-builds=false
-corepack pnpm --ignore-workspace exec playwright install chromium
+CI=true corepack pnpm install --frozen-lockfile --config.strict-dep-builds=false
+corepack pnpm exec playwright install chromium
 printf '%s\n' '***'

--- a/.arashi/hooks/post-create.arashi-vscode.sh
+++ b/.arashi/hooks/post-create.arashi-vscode.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 printf '%s\n' '***'
-CI=true corepack pnpm --ignore-workspace install --frozen-lockfile
+CI=true corepack pnpm install --frozen-lockfile
 printf '%s\n' '***'

--- a/.arashi/hooks/post-create.arashi.sh
+++ b/.arashi/hooks/post-create.arashi.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 printf '%s\n' '***'
-CI=true corepack pnpm --ignore-workspace install --frozen-lockfile
-corepack pnpm --ignore-workspace run build
+CI=true corepack pnpm install --frozen-lockfile
+corepack pnpm run build
 printf '%s\n' '***'

--- a/.github/workflows/cross-repo-command-contracts.yml
+++ b/.github/workflows/cross-repo-command-contracts.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "scripts/**"
       - "tests/**"
+      - ".arashi/hooks/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig.json"
@@ -49,6 +50,12 @@ jobs:
           repository: corwinm/arashi-vscode
           ref: main
           path: meta/repos/arashi-vscode
+      - name: Check out Arashi presentation
+        uses: actions/checkout@v7
+        with:
+          repository: corwinm/arashi-presentation
+          ref: main
+          path: meta/repos/arashi-presentation
       - name: Use matching coordinated child branches when available
         shell: bash
         run: |
@@ -56,7 +63,7 @@ jobs:
           if [ -z "${GITHUB_HEAD_REF:-}" ]; then
             exit 0
           fi
-          for repo in arashi arashi-docs arashi-skills arashi-vscode; do
+          for repo in arashi arashi-docs arashi-skills arashi-vscode arashi-presentation; do
             if git -C "meta/repos/$repo" ls-remote --exit-code --heads origin "refs/heads/$GITHUB_HEAD_REF" >/dev/null 2>&1; then
               git -C "meta/repos/$repo" fetch --depth=1 origin "refs/heads/$GITHUB_HEAD_REF"
               git -C "meta/repos/$repo" checkout --detach FETCH_HEAD
@@ -73,7 +80,7 @@ jobs:
       - name: Report revisions
         working-directory: meta
         run: |
-          for repo in arashi arashi-docs arashi-skills arashi-vscode; do
+          for repo in arashi arashi-docs arashi-skills arashi-vscode arashi-presentation; do
             printf '%s: ' "$repo"
             git -C "repos/$repo" rev-parse HEAD
           done

--- a/scripts/hook-contracts.ts
+++ b/scripts/hook-contracts.ts
@@ -166,24 +166,46 @@ export async function checkHookContracts(
         "Required setup must fail fast and must not mask failures.",
       );
     }
+    const repository = source
+      .replace(".arashi/hooks/post-create.", "")
+      .replace(".sh", "");
+    const workspacePolicySource = `repos/${repository}/pnpm-workspace.yaml`;
+    let hasTrustedBuildPolicy = false;
+    try {
+      const workspacePolicy = await readFile(
+        join(root, workspacePolicySource),
+        "utf8",
+      );
+      hasTrustedBuildPolicy = workspacePolicy.includes("allowBuilds:");
+    } catch {
+      // A child without a local workspace policy still needs ancestor isolation.
+    }
+    const isolatedInstall =
+      "corepack pnpm --ignore-workspace install --frozen-lockfile";
+    const childWorkspaceInstall = "corepack pnpm install --frozen-lockfile";
     if (
-      !content.includes(
-        "corepack pnpm --ignore-workspace install --frozen-lockfile",
-      )
+      !content.includes(isolatedInstall) &&
+      !(hasTrustedBuildPolicy && content.includes(childWorkspaceInstall))
     ) {
       addMetaDiagnostic(
         diagnostics,
         "HOOK_DOGFOOD_PACKAGE_PROVENANCE",
         source,
-        "Use the child-pinned ancestor-workspace-safe install command.",
+        "Use an ancestor-isolated install or a child-local workspace boundary with reviewed build policy.",
+      );
+    }
+    if (hasTrustedBuildPolicy && content.includes(isolatedInstall)) {
+      addMetaDiagnostic(
+        diagnostics,
+        "HOOK_DOGFOOD_BUILD_POLICY_IGNORED",
+        source,
+        `Do not ignore ${workspacePolicySource}; it defines the child's trusted dependency builds.`,
       );
     }
     if (
       source === ".arashi/hooks/post-create.arashi-presentation.sh" &&
       content.includes("--config.strict-dep-builds=false") &&
-      !content.includes(
-        "corepack pnpm --ignore-workspace exec playwright install chromium",
-      )
+      !content.includes("corepack pnpm exec playwright install chromium")
     ) {
       addMetaDiagnostic(
         diagnostics,

--- a/scripts/hook-contracts.ts
+++ b/scripts/hook-contracts.ts
@@ -52,6 +52,31 @@ export async function checkHookContracts(
   root: string,
 ): Promise<HookContractResult> {
   const diagnostics: HookContractDiagnostic[] = [];
+  const workflowSource = ".github/workflows/cross-repo-command-contracts.yml";
+  let workflowContent = "";
+  try {
+    workflowContent = await readFile(join(root, workflowSource), "utf8");
+  } catch (error) {
+    addMetaDiagnostic(
+      diagnostics,
+      "HOOK_DOGFOOD_WORKFLOW_MISSING",
+      workflowSource,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  for (const hookSource of dogfoodPostCreateHooks) {
+    const repository = hookSource
+      .replace(".arashi/hooks/post-create.", "")
+      .replace(".sh", "");
+    if (!workflowContent.includes(`path: meta/repos/${repository}`)) {
+      addMetaDiagnostic(
+        diagnostics,
+        "HOOK_DOGFOOD_REPOSITORY_UNAVAILABLE",
+        workflowSource,
+        `Check out ${repository} so its local pnpm workspace policy is available to the contract checker.`,
+      );
+    }
+  }
 
   for (const surface of surfaces) {
     let content: string;

--- a/tests/hook-contracts.test.ts
+++ b/tests/hook-contracts.test.ts
@@ -15,10 +15,15 @@ const files = {
   "repos/arashi-docs/public/llms-full.txt": `ARASHI_BRANCH_NAME ARASHI_REMOVE_TARGETS_JSON 300000 .ps1 .cmd .bat supported throughout 1.x`,
   "repos/arashi-skills/skills/arashi/references/hooks.md": `ARASHI_BRANCH_NAME ARASHI_REMOVE_TARGETS_JSON 300000 .ps1 .cmd .bat supported throughout 1.x`,
   ".arashi/config.json": JSON.stringify({ hooks: { timeout: 300000 } }),
-  ".arashi/hooks/post-create.arashi.sh": `set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile`,
-  ".arashi/hooks/post-create.arashi-docs.sh": `set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile`,
-  ".arashi/hooks/post-create.arashi-presentation.sh": `set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile`,
-  ".arashi/hooks/post-create.arashi-vscode.sh": `set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile`,
+  ".arashi/hooks/post-create.arashi.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
+  ".arashi/hooks/post-create.arashi-docs.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
+  ".arashi/hooks/post-create.arashi-presentation.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
+  ".arashi/hooks/post-create.arashi-vscode.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
+  "repos/arashi/pnpm-workspace.yaml": "allowBuilds:\n  esbuild: true\n",
+  "repos/arashi-docs/pnpm-workspace.yaml": "allowBuilds:\n  esbuild: true\n",
+  "repos/arashi-presentation/pnpm-workspace.yaml":
+    "allowBuilds:\n  playwright-chromium: true\n",
+  "repos/arashi-vscode/pnpm-workspace.yaml": "allowBuilds:\n  esbuild: true\n",
   ".arashi/hooks/pre-remove.sh": `ARASHI_REMOVE_TARGETS_JSON\ntmux list-panes -a -F '#{pane_current_path}'\n[[ "$pane_path" == "$target_path" ]]`,
 };
 
@@ -110,6 +115,21 @@ describe("cross-repository lifecycle-hook contract", () => {
     );
   });
 
+  test("rejects dogfood setup that ignores a child-local trusted-build policy", async () => {
+    const root = await fixture({
+      ".arashi/hooks/post-create.arashi.sh":
+        "set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile",
+      "repos/arashi/pnpm-workspace.yaml": "allowBuilds:\n  esbuild: true\n",
+    });
+    const result = await checkHookContracts(root);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "HOOK_DOGFOOD_BUILD_POLICY_IGNORED",
+        source: ".arashi/hooks/post-create.arashi.sh",
+      }),
+    );
+  });
+
   test("rejects substring-based tmux cleanup", async () => {
     const root = await fixture({
       ".arashi/hooks/pre-remove.sh": `ARASHI_WORKTREE_PATH\n[[ "$session_name" == *"$worktree_name"* ]]`,
@@ -131,7 +151,7 @@ describe("cross-repository lifecycle-hook contract", () => {
   test("requires an explicit trusted build replacement when strict dependency builds are disabled", async () => {
     const root = await fixture({
       ".arashi/hooks/post-create.arashi-presentation.sh":
-        "set -euo pipefail\nCI=true corepack pnpm --ignore-workspace install --frozen-lockfile --config.strict-dep-builds=false",
+        "set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile --config.strict-dep-builds=false",
     });
     const result = await checkHookContracts(root);
     expect(result.diagnostics).toContainEqual(

--- a/tests/hook-contracts.test.ts
+++ b/tests/hook-contracts.test.ts
@@ -15,6 +15,12 @@ const files = {
   "repos/arashi-docs/public/llms-full.txt": `ARASHI_BRANCH_NAME ARASHI_REMOVE_TARGETS_JSON 300000 .ps1 .cmd .bat supported throughout 1.x`,
   "repos/arashi-skills/skills/arashi/references/hooks.md": `ARASHI_BRANCH_NAME ARASHI_REMOVE_TARGETS_JSON 300000 .ps1 .cmd .bat supported throughout 1.x`,
   ".arashi/config.json": JSON.stringify({ hooks: { timeout: 300000 } }),
+  ".github/workflows/cross-repo-command-contracts.yml": `
+path: meta/repos/arashi
+path: meta/repos/arashi-docs
+path: meta/repos/arashi-presentation
+path: meta/repos/arashi-vscode
+`,
   ".arashi/hooks/post-create.arashi.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
   ".arashi/hooks/post-create.arashi-docs.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
   ".arashi/hooks/post-create.arashi-presentation.sh": `set -euo pipefail\nCI=true corepack pnpm install --frozen-lockfile`,
@@ -126,6 +132,23 @@ describe("cross-repository lifecycle-hook contract", () => {
       expect.objectContaining({
         code: "HOOK_DOGFOOD_BUILD_POLICY_IGNORED",
         source: ".arashi/hooks/post-create.arashi.sh",
+      }),
+    );
+  });
+
+  test("rejects CI that omits a dogfood hook repository", async () => {
+    const root = await fixture({
+      ".github/workflows/cross-repo-command-contracts.yml": `
+path: meta/repos/arashi
+path: meta/repos/arashi-docs
+path: meta/repos/arashi-vscode
+`,
+    });
+    const result = await checkHookContracts(root);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "HOOK_DOGFOOD_REPOSITORY_UNAVAILABLE",
+        source: ".github/workflows/cross-repo-command-contracts.yml",
       }),
     );
   });


### PR DESCRIPTION
## Summary

- let repository-specific post-create hooks honor each child repository's local `pnpm-workspace.yaml`
- preserve reviewed pnpm `allowBuilds` policies during clean CI-mode installs
- reject dogfood hooks that combine `--ignore-workspace` with a child-local trusted-build policy
- provision every dogfood-hook repository in contract CI and run CI for hook-only changes

## Root cause

The tracked post-create hooks used `pnpm --ignore-workspace`. With pnpm 11.20, that flag also ignores the child repository's own `pnpm-workspace.yaml`, including its `allowBuilds` entries. A clean CI-mode install therefore rejected required esbuild scripts with `ERR_PNPM_IGNORED_BUILDS`, causing `arashi create` to roll back.

Each affected child already has its own `pnpm-workspace.yaml`, so the hooks can safely use that child-local workspace boundary instead of discarding it.

## Validation

- `CI=true corepack pnpm test` — 140 tests passed
- `CI=true corepack pnpm run typecheck`
- `CI=true corepack pnpm run contracts:hooks`
- Prettier check for changed TypeScript files
- `git diff --check`
- independent pre-commit review: no security concerns or logic errors
- real clean-install smoke test: `arashi create cm/test-2 --no-launch --no-switch`
  - created all six coordinated worktrees
  - all four repository-specific post-create hooks succeeded
  - smoke-test worktrees and branches were subsequently removed with `arashi remove cm/test-2 --force`
